### PR TITLE
Visual Doc: Kind-based coloring

### DIFF
--- a/notes.md
+++ b/notes.md
@@ -1,71 +1,3 @@
-## Wrapping up unit tests / stability / coverage
-
-NOTE: we may need to add multiple retries to tests, CI should pass every time
-if at all possible
-
-NOTE: some bug fixes/stability could be added after we add the feature for markdown documentation
-
-TODO: trouble running tests, try running each one individually
-
-NEW TEST: visual keybinding display
-    - TODO: our tracking of `kinds` has been lost somewhere in refactoring
-        we need to treat this similarly to the way we treat definitions
-        and then pass it on to the visual docs
-    - FIX: right now if the kind doesn't exist, it just silently
-      fails to generate a color, we should validate the kinds
-    - verify that keys with bindings show up and have color
-    - verify that keys without bindings show up as blank
-
-BUG: when there are no keys defined the visual keybinding output includes `undefined`
-
-NEW TEST: store/restore named commands
-
-create release 0.1.1
-
-SMALL BUG: should 'esc' really be appended in the status bar since it cancels a prefix sequence... 🤔
-
-unit tests: edge cases with recording edits
-  - how about when I switch documents?
-  - how about when we don't start with normal mode commands?
-  - how about long edits with lots of insert mode commands intersprsed with the edits?
-  - what about multiple cursors?
-  - how do recorded commands interact with the palette?
-  - does the command palette show up / not show up with the proper timing?
-
-create release 0.1.2
-
-unit tests: mode capture
-  - cook up some tests `onType` setting of modes
-unit tests: parsing of YAML and JSON(C)
-  - actually: delete this feature (add it back in later if it feels worth it)
-
-create release 0.1.3
-
-UNIT TEST: verify that larkin can be properly loaded/parsed
-
-TODO: include the basic (non ui tests) in coverage
-
-Key gaps identified by coverage (not listed above):
-  - setFlags
-  - use of global state in commands
-    - `editorHasSelection`
-    - `editorHasMultipleSelection`
-    - `firstSelectionOrWord`
-  - testing filter of bindings for palette
-  - test configuration editing
-    - copy
-    - remove
-    - copy from user / default config
-  - commands
-    - usage of `if` field
-    - error for malformed `repeat` expression
-    - macros: recording and replaying edits
-      - nested macros??
-    - empty search string
-    - premature end of capture and search using enter
-    - escaping a search
-  - basic validation of visual search (we can inject css ids to make this easy)
-
 ## Visual Documentation Improvements
 
 release 0.2.0 onwards
@@ -133,6 +65,56 @@ thoughts: things I must have to release:
   + fix default expansion
 
 WHEN PUBLISHING: get this to work on both stores (the one from microsoft and the one that vscodium uses)
+
+## Additional test coverage
+
+SMALL BUG: should 'esc' really be appended in the status bar since it cancels a prefix sequence... 🤔
+
+NEW TEST: store/restore named commands
+
+unit tests: edge cases with recording edits
+  - how about when I switch documents?
+  - how about when we don't start with normal mode commands?
+  - how about long edits with lots of insert mode commands intersprsed with the edits?
+  - what about multiple cursors?
+  - how do recorded commands interact with the palette?
+  - does the command palette show up / not show up with the proper timing?
+
+create release
+
+unit tests: mode capture
+  - cook up some tests `onType` setting of modes
+unit tests: parsing of YAML and JSON(C)
+  - actually: delete this feature (add it back in later if it feels worth it)
+
+create release
+
+UNIT TEST: verify that larkin can be properly loaded/parsed
+
+TODO: include the basic (non ui tests) in coverage
+
+Gaps in coverage:
+  - setFlags
+  - use of global state in commands
+    - `editorHasSelection`
+    - `editorHasMultipleSelection`
+    - `firstSelectionOrWord`
+  - visualKey
+    - toggling modifier keys
+  - testing filter of bindings for palette
+  - test configuration editing
+    - copy
+    - remove
+    - copy from user / default config
+  - commands
+    - usage of `if` field
+    - error for malformed `repeat` expression
+    - macros: recording and replaying edits
+      - nested macros??
+    - empty search string
+    - premature end of capture and search using enter
+    - escaping a search
+  - basic validation of visual search (we can inject css ids to make this easy)
 
 ## Future releases
 

--- a/notes.md
+++ b/notes.md
@@ -8,6 +8,9 @@ NOTE: some bug fixes/stability could be added after we add the feature for markd
 TODO: trouble running tests, try running each one individually
 
 NEW TEST: visual keybinding display
+    - TODO: our tracking of `kinds` has been lost somewhere in refactoring
+        we need to treat this similarly to the way we treat definitions
+        and then pass it on to the visual docs
     - verify that keys with bindings show up and have color
     - verify that keys without bindings show up as blank
 

--- a/notes.md
+++ b/notes.md
@@ -11,6 +11,8 @@ NEW TEST: visual keybinding display
     - TODO: our tracking of `kinds` has been lost somewhere in refactoring
         we need to treat this similarly to the way we treat definitions
         and then pass it on to the visual docs
+    - FIX: right now if the kind doesn't exist, it just silently
+      fails to generate a color, we should validate the kinds
     - verify that keys with bindings show up and have color
     - verify that keys without bindings show up as blank
 

--- a/presets/larkin.toml
+++ b/presets/larkin.toml
@@ -58,11 +58,23 @@ lineNumbers = "relative"
 select_on = false
 around_on = false
 
-kinds = [
-    { name = "motions",   description = "These commands move the cursor and/or selections." },
-    { name = "action",   description = "Actions do something with the selected text (e.g. delete it). Unless otherwise noted, in the absence of a selection, an action will modify an entire line, and a count argument indicates the number of lines (e.g. 3d deletes this line and the next 3 lines)." },
-    { name = "util",     description = "Assorted other commands that aren't motions or actions" },
-]
+[[kind]]
+name = "motions"
+description = "These commands move the cursor and/or selections."
+
+[[kind]]
+name = "action"
+description = """
+Actions do something with the selected text (e.g. delete it). Unless otherwise noted, in
+the absence of a selection, an action will modify an entire line, and a count argument
+indicates the number of lines (e.g. 3d deletes this line and the next 3 lines).
+"""
+
+[[kind]]
+name = "util"
+description = """
+Assorted other commands that aren't motions or actions
+"""
 
 [[define.selectLinesDown]]
 command = "selection-utilities.shrinkToActive"

--- a/src/web/commands/visualKeyDoc.ts
+++ b/src/web/commands/visualKeyDoc.ts
@@ -212,6 +212,10 @@ export class DocViewProvider implements vscode.WebviewViewProvider {
                 const key = modifierKey(binding.args.key).sort().join('.');
                 modifierCounts[key] = get(modifierCounts, key, 0) + 1;
             }
+
+            modifierCounts[''] = modifierCounts[''] === undefined ? 0 : modifierCounts[''];
+            modifierCounts['⇧'] =
+                modifierCounts['⇧'] === undefined ? 0 : modifierCounts['⇧'];
             const modifiers = Object.keys(modifierCounts);
             modifiers.sort((x, y) => modifierCounts[y] - modifierCounts[x]);
             this._modifierOrder = modifiers.map(x => x.split('.'));
@@ -311,7 +315,7 @@ export class DocViewProvider implements vscode.WebviewViewProvider {
         // TODO: we need to dynamically update the top and bottom labels depending on
         // modifiers this will require updating the key-label- divs in `script.js`
         const keys = `
-        <div class="container">
+        <div id="master-key-visual-doc" class="container">
             <div class="keyboard">
                 ${keyRows(['⇧'], [''])
                     .map(

--- a/src/web/commands/visualKeyDoc.ts
+++ b/src/web/commands/visualKeyDoc.ts
@@ -3,9 +3,9 @@ import {withState} from '../state';
 import * as vscode from 'vscode';
 import {MODE} from './mode';
 import z from 'zod';
-import {IConfigKeyBinding} from '../keybindings/processing';
+import {Bindings, IConfigKeyBinding} from '../keybindings/processing';
 import {filterBindingFn} from '../keybindings';
-import {bindings} from '../keybindings/config';
+import {bindings, onChangeBindings} from '../keybindings/config';
 import {PREFIX_CODE} from './prefix';
 import {reverse, uniqBy} from 'lodash';
 import {modifierKey, prettifyPrefix, validateInput} from '../utils';
@@ -132,12 +132,6 @@ function get<T extends object, K extends keyof T>(x: T, key: K, def: T[K]) {
     }
 }
 
-const kindDoc = z.array(
-    z.object({
-        name: z.string(),
-        description: z.string(),
-    })
-);
 interface KindDocEl {
     name: string;
     description: string;
@@ -260,15 +254,10 @@ export class DocViewProvider implements vscode.WebviewViewProvider {
         }
     }
 
-    private updateKinds(values: CommandState | Map<string, unknown>) {
-        const kinds = validateInput(
-            'visual-documentation',
-            values.get('kinds') || [],
-            kindDoc
-        );
+    private updateKinds(bindings: Bindings) {
         this._kinds = {};
         let index = 0;
-        for (const kind of kinds || []) {
+        for (const kind of bindings.kind) {
             this._kinds[kind.name] = {...kind, index};
             index++;
         }
@@ -285,11 +274,10 @@ export class DocViewProvider implements vscode.WebviewViewProvider {
             this.updateKeys(vals);
             return true;
         });
-        this.updateKinds(state);
-        state = state.onSet('kinds', _vals => {
-            this.updateKinds(state);
-            return true;
-        });
+        if (bindings) {
+            this.updateKinds(bindings);
+        }
+        onChangeBindings(async x => (x ? this.updateKinds(x) : undefined));
         return state;
     }
 

--- a/src/web/keybindings/config.ts
+++ b/src/web/keybindings/config.ts
@@ -48,7 +48,8 @@ async function useBindings(label: string) {
                 await fn(bindings);
             }
         }
-    } catch {
+    } catch (e) {
+        console.dir(e);
         vscode.window.showErrorMessage('Could not load bindings with label: ' + configFile);
     }
 }

--- a/src/web/keybindings/parsing.ts
+++ b/src/web/keybindings/parsing.ts
@@ -331,10 +331,19 @@ const modeSpec = z.object({
 });
 export type ModeSpec = z.output<typeof modeSpec>;
 
+const kindItem = z
+    .object({
+        name: z.string(),
+        description: z.string(),
+    })
+    .strict();
+export type KindItem = z.output<typeof kindItem>;
+
 export const bindingSpec = z
     .object({
         header: bindingHeader,
         bind: rawBindingItem.array(),
+        kind: kindItem.array().optional(),
         path: bindingPath
             .array()
             .refine(xs => uniqBy(xs, x => x.id).length === xs.length, {

--- a/src/web/keybindings/processing.ts
+++ b/src/web/keybindings/processing.ts
@@ -11,6 +11,7 @@ import {
     ParsedWhen,
     ModeSpec,
     doArgs,
+    KindItem,
 } from './parsing';
 import z from 'zod';
 import {
@@ -31,6 +32,7 @@ import {fromZodError} from 'zod-validation-error';
 export interface Bindings {
     name?: string;
     description?: string;
+    kind: KindItem[];
     define: Record<string, unknown>;
     mode: Record<string, ModeSpec>;
     bind: IConfigKeyBinding[];
@@ -52,6 +54,7 @@ export function processBindings(spec: BindingSpec): [Bindings, string[]] {
     const configItems = newItems.map(i => itemToConfigBinding(i, definitions));
     const result: Bindings = {
         name: spec.header.name,
+        kind: spec.kind || [],
         description: spec.header.description,
         define: definitions,
         mode: mapByName(spec.mode),

--- a/src/web/status/keyseq.ts
+++ b/src/web/status/keyseq.ts
@@ -7,7 +7,7 @@ import {prettifyPrefix} from '../utils';
 
 let keyStatusBar: vscode.StatusBarItem | undefined = undefined;
 
-const KEY_DISPLAY_DELAY_DEFAULT = process.env.TESTING ? 100 : 500;
+const KEY_DISPLAY_DELAY_DEFAULT = process.env.TESTING ? 180 : 500;
 let keyDisplayDelay: number = KEY_DISPLAY_DELAY_DEFAULT;
 let statusUpdates = Number.MIN_SAFE_INTEGER;
 

--- a/test/specs/utils.mts
+++ b/test/specs/utils.mts
@@ -236,7 +236,7 @@ export async function enterModalKeys(...keySeq: ModalKey[]){
         }
         let currentKeySeqString = (count ? count + "× " : '') + keySeqString;
 
-        browser.keys(keyCodes);
+        await browser.keys(keyCodes);
         if(modalKeyUpdateStatus(keys_)){
             let registered = await browser.waitUntil(() =>
                 statusBar.getItem('Keys Typed: '+currentKeySeqString),

--- a/test/specs/utils.mts
+++ b/test/specs/utils.mts
@@ -236,7 +236,8 @@ export async function enterModalKeys(...keySeq: ModalKey[]){
         }
         let currentKeySeqString = (count ? count + "× " : '') + keySeqString;
 
-        await browser.keys(keyCodes);
+        // we do *NOT* await here, so that we can catch display events that are fast
+        browser.keys(keyCodes);
         if(modalKeyUpdateStatus(keys_)){
             let registered = await browser.waitUntil(() =>
                 statusBar.getItem('Keys Typed: '+currentKeySeqString),

--- a/test/specs/visualDoc.ux.mts
+++ b/test/specs/visualDoc.ux.mts
@@ -1,0 +1,116 @@
+// start with just some basic tests to verify all is well
+
+import '@wdio/globals';
+import 'wdio-vscode-service';
+import { enterModalKeys, setBindings, setupEditor, movesCursorInEditor, storeCoverageStats } from './utils.mts';
+import { InputBox, sleep, TextEditor, Workbench } from 'wdio-vscode-service';
+import { Key } from "webdriverio";
+
+describe('Visual Docs', () => {
+    let editor: TextEditor;
+    let workbench: Workbench;
+    before(async () => {
+        await setBindings(`
+            [header]
+            version = "1.0"
+
+            [[mode]]
+            name = "insert"
+            default = true
+
+            [[mode]]
+            name = "normal"
+
+            [[kind]]
+            name = "left keys"
+            description = "more leftward keys"
+
+            [[kind]]
+            name = "right keys"
+            description = "more rightward keys"
+
+            [[bind]]
+            name = "normal mode"
+            key = "escape"
+            command = "master-key.enterNormal"
+            prefixes = "<all-prefixes>"
+            hideInPalette = true
+
+            [[path]]
+            id = "motion"
+            name = "basic motions"
+            default.command = "cursorMove"
+            default.mode = "normal"
+            default.when = "editorTextFocus"
+            default.computedArgs.value = "count"
+
+            [[bind]]
+            path = "motion"
+            name = "left"
+            key = "h"
+            args.to = "left"
+            kind = "left"
+
+            [[bind]]
+            path = "motion"
+            name = "right"
+            key = "l"
+            args.to = "right"
+            kind = "right"
+
+            [[bind]]
+            path = "motion"
+            name = "down"
+            key = "j"
+            args.to = "down"
+            kind = "left"
+
+            [[bind]]
+            path = "motion"
+            name = "up"
+            key = "k"
+            args.to = "up"
+            kind = "right"
+
+            [[bind]]
+            name = "insert mode"
+            key = "i"
+            command = "master-key.enterInsert"
+            mode = "normal"
+            kind = "right"
+        `);
+        editor = await setupEditor(`A simple test`);
+        workbench = await browser.getWorkbench();
+    });
+
+    it('Shows All Bindings', async() => {
+        await browser.keys(Key.Escape);
+        await editor.moveCursor(1, 1);
+
+        await workbench.executeCommand("Master Key: Show Visual Documentation")
+
+        const keyEl = await browser.$('');
+
+        expect(await picks[0].getLabel()).toEqual("H");
+        expect(await picks[0].getDescription()).toEqual("left");
+        expect(await picks[1].getLabel()).toEqual("L");
+        expect(await picks[1].getDescription()).toEqual("right");
+        expect(await picks[2].getLabel()).toEqual("J");
+        expect(await picks[2].getDescription()).toEqual("down");
+        expect(await picks[3].getLabel()).toEqual("K");
+        expect(await picks[3].getDescription()).toEqual("up");
+        expect(await picks[4].getLabel()).toEqual("I");
+        expect(await picks[4].getDescription()).toEqual("insert mode");
+        await enterModalKeys('i');
+    });
+
+    // NOTE: it would be ideal if we could also test how the palette interacts with typing
+    // when there is a delay set, and in the two distinct modes (searching or keybinding).
+    // However the way focus and typing work with chromedriver does not replicate actual UX
+    // interactions as a user at least as far as I can tell, so this behavior cannot
+    // currently be automated.
+
+    after(async () => {
+        await storeCoverageStats('visualDoc');
+    });
+});

--- a/test/specs/visualDoc.ux.mts
+++ b/test/specs/visualDoc.ux.mts
@@ -22,11 +22,11 @@ describe('Visual Docs', () => {
             name = "normal"
 
             [[kind]]
-            name = "left keys"
+            name = "left"
             description = "more leftward keys"
 
             [[kind]]
-            name = "right keys"
+            name = "right"
             description = "more rightward keys"
 
             [[bind]]
@@ -83,25 +83,47 @@ describe('Visual Docs', () => {
         workbench = await browser.getWorkbench();
     });
 
-    it('Shows All Bindings', async() => {
+    it('Labels Keys', async() => {
+        await browser.keys(Key.Escape);
+        await editor.moveCursor(1, 1);
+
+        await workbench.executeCommand("Master Key: Show Visual Documentation")
+        await sleep(1000);
+
+        const hKey = await browser.$('div.key > div.bottom=left');
+        expect(await hKey).toHaveText('left');
+
+        const jKey = await browser.$('div.key > div.bottom=down');
+        expect(await jKey).toHaveText('down');
+
+        const kKey = await browser.$('div.key > div.bottom=up');
+        expect(await kKey).toHaveText('up');
+
+        const lKey = await browser.$('div.key > div.bottom=right');
+        expect(await lKey).toHaveText('right');
+    });
+
+    it('Colors Keys', async() => {
         await browser.keys(Key.Escape);
         await editor.moveCursor(1, 1);
 
         await workbench.executeCommand("Master Key: Show Visual Documentation")
 
-        const keyEl = await browser.$('');
+        const hKey = await browser.$('div.key > div.bottom=h');
+        const hClasses = await hKey.getAttribute('class')
+        expect(hClasses).toMatch('kind-color-1')
 
-        expect(await picks[0].getLabel()).toEqual("H");
-        expect(await picks[0].getDescription()).toEqual("left");
-        expect(await picks[1].getLabel()).toEqual("L");
-        expect(await picks[1].getDescription()).toEqual("right");
-        expect(await picks[2].getLabel()).toEqual("J");
-        expect(await picks[2].getDescription()).toEqual("down");
-        expect(await picks[3].getLabel()).toEqual("K");
-        expect(await picks[3].getDescription()).toEqual("up");
-        expect(await picks[4].getLabel()).toEqual("I");
-        expect(await picks[4].getDescription()).toEqual("insert mode");
-        await enterModalKeys('i');
+        const jKey = await browser.$('div.key > div.bottom=j');
+        const jClasses = await jKey.getAttribute('class')
+        expect(jClasses).toMatch('kind-color-1')
+
+        const kKey = await browser.$('div.key > div.bottom=k');
+        const kClasses = await kKey.getAttribute('class')
+        expect(kClasses).toMatch('kind-color-2')
+
+        const lKey = await browser.$('div.key > div.bottom=l');
+        const lClasses = await lKey.getAttribute('class')
+        expect(lClasses).toMatch('kind-color-2')
     });
 
     // NOTE: it would be ideal if we could also test how the palette interacts with typing

--- a/test/specs/visualDoc.ux.mts
+++ b/test/specs/visualDoc.ux.mts
@@ -153,8 +153,10 @@ describe('Visual Docs', () => {
         expect(wLabel).toHaveText('W');
         const wName = (await wLabel.parentElement()).$('div.name.bottom');
         expect(wName).toHaveText('funny right');
-        const wClasses = await wLabel.getAttribute('class')
-        expect(wClasses).toMatch('kind-color-1')
+        const wClasses = await wLabel.getAttribute('class');
+        expect(wClasses).toMatch('kind-color-1');
+
+        await browser.keys('w');
 
         await docView.close();
     });

--- a/wdio.conf.mts
+++ b/wdio.conf.mts
@@ -91,7 +91,7 @@ export const config: Options.Testrunner = {
     // Define all options that are relevant for the WebdriverIO instance here
     //
     // Level of logging verbosity: trace | debug | info | warn | error | silent
-    logLevel: 'info',
+    logLevel: process.env.COVERAGE ? 'warn' : 'info',
     //
     // Set specific log levels per logger
     // loggers:


### PR DESCRIPTION
In older commits, visual doc keys got colored based on their "kind", this PR will restore this feature and generate tests to check that visual doc keys get appropriately populated and have appropriate color styling.