### PR TITLE
Fix bug in markdown documentation generation

### DIFF
--- a/notes.md
+++ b/notes.md
@@ -4,6 +4,9 @@ While the unit tests for doc display works, somewhere in the process of getting 
 to work, Larkin doc display was broken. I've narrowed this down to an issue with resolving
 the indexing/alignment of the markdown doc parsing and data parsing.
 
+bug fixed
+- todo: write a test that would catch the bug
+
 ## Optimization
 
 release 0.2.1

--- a/notes.md
+++ b/notes.md
@@ -1,15 +1,12 @@
-## Debug
+## Debug doc problem
 
 While the unit tests for doc display works, somewhere in the process of getting those
 to work, Larkin doc display was broken. I've narrowed this down to an issue with resolving
 the indexing/alignment of the markdown doc parsing and data parsing.
 
-bug fixed
-- todo: write a test that would catch the bug
-
 ## Optimization
 
-release 0.2.1
+release 0.2.2
 
 low hanging fruit?: avoid re-rendering visual docs multiple times on every key press
 

--- a/notes.md
+++ b/notes.md
@@ -1,3 +1,9 @@
+## Debug
+
+While the unit tests for doc display works, somewhere in the process of getting those
+to work, Larkin doc display was broken. I've narrowed this down to an issue with resolving
+the indexing/alignment of the markdown doc parsing and data parsing.
+
 ## Optimization
 
 release 0.2.1

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Master Key",
   "publisher": "haberdashPI",
   "description": "Master your keybindings with documentation, discoverability, modal bindings and expressive configuration",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "repository": {
     "url": "https://github.com/haberdashPi/vscode-master-key"
   },

--- a/src/web/utils.ts
+++ b/src/web/utils.ts
@@ -74,3 +74,15 @@ export function prettifyPrefix(str: string) {
     str = replaceAll(str, /,{2,}/gi, ',');
     return str;
 }
+
+export interface IIndexed {
+    index: number;
+}
+
+export function get<T extends object, K extends keyof T>(x: T, key: K, def: T[K]) {
+    if (key in x && x[key] !== undefined) {
+        return x[key];
+    } else {
+        return def;
+    }
+}

--- a/src/web/utils.ts
+++ b/src/web/utils.ts
@@ -78,11 +78,3 @@ export function prettifyPrefix(str: string) {
 export interface IIndexed {
     index: number;
 }
-
-export function get<T extends object, K extends keyof T>(x: T, key: K, def: T[K]) {
-    if (key in x && x[key] !== undefined) {
-        return x[key];
-    } else {
-        return def;
-    }
-}

--- a/test/specs/markdownDocs.ux.mts
+++ b/test/specs/markdownDocs.ux.mts
@@ -71,6 +71,18 @@ describe('Binding Docs', () => {
             args.to = "down"
             kind = "left"
 
+            #- verify that including lots of ignored keys doesn't mess up display
+            [[bind]]
+            name = "ignore"
+            foreach.key = ['{key: .}']
+            key = "{key}"
+            command = "master-key.ignore"
+            hideInDocs = true
+            hideInPalette = true
+            priority = -10
+            when = "editorTextFocus"
+            mode = "normal"
+
             # ## Second Section
 
             # Aliquip ipsum enim cupidatat aute occaecat magna nostrud qui labore.
@@ -100,9 +112,7 @@ describe('Binding Docs', () => {
             # Final paragraph shows up.
         `);
 
-        console.log("[DEBUG]: setup bindings")
         const workbench = await browser.getWorkbench();
-        await sleep(5000);
         // console.log("[DEBUG]: showing documentation")
         // await workbench.executeCommand('Master Key: Show Text Documentation')
         await browser.waitUntil(async () => (await workbench.getAllWebviews()).length > 1)


### PR DESCRIPTION
Release 0.2.0 had a bug in the final implementation that was not caught by unit tests, but did show up for Larkin. This bug removed all binding tables from Larkin's markdown documentation. The root cause was that the older implementation assumed all bindings would be provided in the order of their index, which was not the case. They are sorted by `priority`.

This PR implements moves to an easier to follow implementation that 1.) indexes all resolved bindings by their `index` and 2.) includes an index field for documentation bindings. We can get then straightforwardly match resolved bindings to documentation bindings.