### PR TITLE
Fix nested macro replay

### DIFF
--- a/src/web/commands/replay.ts
+++ b/src/web/commands/replay.ts
@@ -4,7 +4,7 @@ import {validateInput} from '../utils';
 import {EvalContext} from '../expressions';
 import {withState, CommandResult, recordedCommand} from '../state';
 import {doCommands, RecordedCommandArgs, RunCommandsArgs, COMMAND_HISTORY} from './do';
-import {uniq, cloneDeep} from 'lodash';
+import {uniq} from 'lodash';
 import {List} from 'immutable';
 
 const selectHistoryArgs = z
@@ -149,7 +149,7 @@ async function replayFromHistory(args: unknown): Promise<CommandResult> {
     const commands = await selectHistoryCommand('master-key.replayFromHistory', args);
     if (commands) {
         await runCommandHistory(commands);
-        return {...(<object>args), value: cloneDeep(commands)};
+        return {...(<object>args), value: commands};
     }
     return;
 }

--- a/src/web/commands/replay.ts
+++ b/src/web/commands/replay.ts
@@ -4,14 +4,14 @@ import {validateInput} from '../utils';
 import {EvalContext} from '../expressions';
 import {withState, CommandResult, recordedCommand} from '../state';
 import {doCommands, RecordedCommandArgs, RunCommandsArgs, COMMAND_HISTORY} from './do';
-import {uniq} from 'lodash';
+import {uniq, cloneDeep} from 'lodash';
 import {List} from 'immutable';
 
 const selectHistoryArgs = z
     .object({
         range: z.object({from: z.string(), to: z.string()}).optional(),
         at: z.string().optional(),
-        value: z.object({}).array().optional(),
+        value: z.object({}).passthrough().array().optional(),
         register: z.string().optional(),
     })
     .strict()
@@ -149,6 +149,7 @@ async function replayFromHistory(args: unknown): Promise<CommandResult> {
     const commands = await selectHistoryCommand('master-key.replayFromHistory', args);
     if (commands) {
         await runCommandHistory(commands);
+        return {...(<object>args), value: cloneDeep(commands)};
     }
     return;
 }

--- a/test/specs/replay.ux.mts
+++ b/test/specs/replay.ux.mts
@@ -448,7 +448,7 @@ i j k l`);
         await waitForMode('rec: normal');
         await movesCursorInEditor(async () => {
             await enterModalKeys('l');
-            await enterModalKeys('q l');
+            await enterModalKeys('q', {key: 'l', updatesStatus: false});
         }, [0, 2], editor);
         await enterModalKeys(['shift', 'q']);
         await waitForMode('normal');

--- a/test/specs/replay.ux.mts
+++ b/test/specs/replay.ux.mts
@@ -2,6 +2,7 @@ import { browser, expect } from '@wdio/globals';
 import { Key } from 'webdriverio';
 import { setBindings, setupEditor, movesCursorInEditor, enterModalKeys, waitForMode, storeCoverageStats } from './utils.mts';
 import { sleep, InputBox, TextEditor, Workbench } from 'wdio-vscode-service';
+import { moveCursor } from 'readline';
 
 describe('Replay', () => {
     let editor: TextEditor;
@@ -437,6 +438,28 @@ i j k l`);
             await enterModalKeys({key: ['shift', '2'], count: 2}, 'q',
                 {key: 'c', updatesStatus: false});
         }, [0, 3], editor);
+    });
+
+    it('Handles nested replay', async () => {
+        await editor.moveCursor(1, 1);
+        await enterModalKeys('escape');
+
+        await enterModalKeys(['shift', 'q'])
+        await waitForMode('rec: normal');
+        await movesCursorInEditor(async () => {
+            await enterModalKeys('l');
+            await enterModalKeys('q l');
+        }, [0, 2], editor);
+        await enterModalKeys(['shift', 'q']);
+        await waitForMode('normal');
+
+        await movesCursorInEditor(async () => {
+            await enterModalKeys('q', {key: 'q', updatesStatus: false});
+        }, [0, 2], editor);
+
+        await movesCursorInEditor(async () => {
+            await enterModalKeys('q', {key: 'q', updatesStatus: false});
+        }, [0, 2], editor);
     });
 
     after(async () => {


### PR DESCRIPTION
Bugfix: during macro replay repeat commands do not use the originally repeated command.

This was due to the failure of replay to reify its arguments.

- `replay` tests test for nested replay
- `replayFromHistory` properly reifies the replayed command
