### PR TITLE
Larkin Bindings: remove bad bindings, add some new ones

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Master Key",
   "publisher": "haberdashPI",
   "description": "Master your keybindings with documentation, discoverability, modal bindings, macros and expressive configuration",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "icon": "logo.png",
   "repository": {
     "url": "https://github.com/haberdashPi/vscode-master-key"

--- a/presets/larkin.toml
+++ b/presets/larkin.toml
@@ -10,7 +10,7 @@
 # Some key features:
 
 # - Commands are modal: most actions are available in `normal` mode, while typing occurs in `insert` mode
-# - Command are organized around noun-verb ordering: e.g. `w` selects a word, and `d` will then deletes it.
+# - Command are organized around noun-verb ordering: e.g. `w` selects a word, and `d` will then delete it.
 # - Selection is sticky: once a selection is created, further commands tend to extend that selection until it is reset (using `v`). However a number of commands are defined to automatically reset the selection (e.g. `mw` creates a new selection around a word).
 
 #
@@ -351,6 +351,7 @@ description = "move down, relative to page size"
 command = "selection-utilities.activePageMove"
 args.dir = "down"
 computedArgs.count = "(count || 1)/3"
+computedArgs.select = "mode == 'normal'"
 
 [[bind]]
 path = "edit.motion.prim"
@@ -362,6 +363,7 @@ description = "move up, relative to page size"
 command = "selection-utilities.activePageMove"
 args.dir = "up"
 computedArgs.count = "(count || 1)/3"
+computedArgs.select = "mode == 'normal'"
 
 [[bind]]
 path = "edit.motion.prim"

--- a/presets/larkin.toml
+++ b/presets/larkin.toml
@@ -185,8 +185,9 @@ foreach.key = ["escape", "ctrl+["]
 key = "{key}"
 hideInPalette = true
 hideInDocs = true
-when = "suggsetWidgetVisible && editorTextFocus && !findWidgetVisible"
-command = "master-key.enterNormal"
+when = "suggestWidgetVisible && editorTextFocus && !findWidgetVisible"
+command = "runCommands"
+args.commands = ["hideSuggestWidget", "master-key.enterNormal"]
 mode = []
 prefixes = "<all-prefixes>"
 
@@ -655,7 +656,11 @@ Repeat the last motion command. Motions usually move the cursor or change the se
 """
 repeat = "count"
 command = "master-key.replayFromHistory"
-args.at = "commandHistory[i].path.startsWith('edit.motion') && commandHistory[i].name != 'repeat motion'"
+args.at = """
+commandHistory[i].path.startsWith('edit.motion') &&
+commandHistory[i].name != 'repeat motion' &&
+commandHistory[i].name != 'shrink selection'
+"""
 
 [[bind]]
 path = "edit.motion.history"
@@ -1750,6 +1755,8 @@ args.commands = ["cursorRight", "editor.action.clipboardPasteAction"]
 [[bind]]
 path = "edit.action.clipboard"
 key = "ctrl+p"
+when = "!suggestWidgetVisible"
+mode = ["normal", "insert"]
 name = "paste in"
 combinedName = "paste before/after/in"
 description = "Paste clipboard at location"

--- a/presets/larkin.toml
+++ b/presets/larkin.toml
@@ -342,6 +342,7 @@ command = "expandLineSelection"
 [[bind]]
 path = "edit.motion.prim"
 key = "ctrl+d"
+mode = ["normal", "insert"]
 name = "pg ↓"
 combinedName = "pg ↓/↑"
 combinedKey = "ctrl+d/ctrl+u"
@@ -354,6 +355,7 @@ computedArgs.count = "(count || 1)/3"
 [[bind]]
 path = "edit.motion.prim"
 key = "ctrl+u"
+mode = ["normal", "insert"]
 name = "pg ↑"
 combinedName = "pg ↓/↑"
 description = "move up, relative to page size"
@@ -1043,30 +1045,6 @@ computedArgs.value = "count || 1"
 
 [[bind]]
 path = "edit.motion.obj"
-key = "g /"
-priority = 1
-name = "comment →"
-description = "next comment"
-combinedKey = "/ (shift+/)"
-combinedName = "comment → (←)"
-combinedDescription = "move to next (previous) comment"
-args.unit = "comment"
-args.boundary = "both"
-computedArgs = { value = "count || 1" }
-
-[[bind]]
-path = "edit.motion.obj"
-key = "g shift+/"
-priority = 1
-name = "comment ←"
-combinedName = "comment → (←)"
-description = "previous comment"
-args.unit = "comment"
-args.boundary = "both"
-computedArgs = { value = "-(count || 1)" }
-
-[[bind]]
-path = "edit.motion.obj"
 key = "g 0"
 priority = 1
 name = "sec →"
@@ -1480,25 +1458,6 @@ all text at the same indentation level and the line just above it (ala python sy
 """
 combinedName = "in/arnd"
 command = "vscode-select-by-indent.select-outer-top-only"
-
-[[bind]]
-path = "edit.motion.match.obj"
-key = "m /"
-name = "comment →"
-combinedName = "comment →/←"
-combinedKey = "/ (shift+/)"
-args.unit = "comment"
-args.boundary = "both"
-computedArgs.value = "count || 1"
-
-[[bind]]
-path = "edit.motion.match.obj"
-key = "m shift+/"
-name = "comment ←"
-combinedName = "comment →/←"
-args.unit = "comment"
-args.boundary = "both"
-computedArgs.value = "-(count || 1)"
 
 [[path]]
 id = "edit.motion.match.cell"


### PR DESCRIPTION
This is a hodge podge of improvements to the Larkin bindings:

1. Adds `ctrl+p` for paste in insert mode
2. Adds `ctrl+d/u` for page up down in insert mode
3. Changes `;` behavior to ignore the `shrink selections` motion when getting the last motion
4. Removed comment-navigation commands: `g (shift+)/` and `m (shift+)/` (see below for rationale and user config to reproduce)

The `ctrl+d/u` commands use a new feature of `selection-utilities` version 0.6.6 that allows the page up/down to *not* select text during navigation. (The command differ from
the default page up/down in that they are responsive to `count` usage)

Closes #24. No additional missing motion units (beyond `comment`) were found in my search.

The comment navigation was removed because it requires the user to customize `selection-utilities.motionUnit` for each specific language. For example, I have this in my config:

```json
    "selection-utilities.motionUnits": [
        {
            "name": "paragraph",
            "regexs": "\\S+"
        },
        {
            "name": "section",
            "regexs": [
                ".+",
                "^.*========+.*$"
            ]
        },
        {
            "name": "comment",
            "regexs": "^\\s*//.*$"
        },
        {
            "name": "subsection",
            "regexs": [
                ".+",
                "^.*(========+|--------+).*$"
            ]
        },
        {
            "name": "pluto_cell",
            "regexs": "^# ╔═╡ "
        },
        {
            "name": "WORD",
            "regex": "[^\\s]+"
        },
        {
            "name": "word",
            "regex": "(_*[\\p{L}][_\\p{L}0-9]*)|(_+)|([0-9][0-9.]*)|((?<=[\\s\\r\\n])[^\\p{L}^\\s]+(?=[\\s\\r\\n]))"
        },
        {
            "name": "subword",
            "regex": "(_*[\\p{L}][0-9\\p{Ll}]+_*)|(_+)|(\\p{Lu}[\\p{Lu}0-9]+_*(?!\\p{Ll}))|(\\p{L})|([^\\p{L}^\\s^0-9]+)|([0-9][0-9.]*)"
        },
        {
            "name": "subident",
            "regex": "(\\p{L}[0-9\\p{Ll}]+)|([0-9][0-9.]*)"
        },
        {
            "name": "number",
            "regex": "[0-9][0-9.]*"
        },
        {
            "name": "integer",
            "regex": "[0-9]+"
        }
    ],
```

And then I define the bindings in `masterkeys.toml` as follows:

```toml
#- Comment motions

[[bind]]
path = "edit.motion.obj"
key = "g /"
priority = 1
name = "comment →"
description = "next comment"
combinedKey = "/ (shift+/)"
combinedName = "comment → (←)"
combinedDescription = "move to next (previous) comment"
args.unit = "comment"
args.boundary = "both"
computedArgs = { value = "count || 1" }

[[bind]]
path = "edit.motion.obj"
key = "g shift+/"
priority = 1
name = "comment ←"
combinedName = "comment → (←)"
description = "previous comment"
args.unit = "comment"
args.boundary = "both"
computedArgs = { value = "-(count || 1)" }

[[bind]]
path = "edit.motion.match.obj"
key = "m /"
name = "comment →"
combinedName = "comment →/←"
combinedKey = "/ (shift+/)"
args.unit = "comment"
args.boundary = "both"
computedArgs.value = "count || 1"

[[bind]]
path = "edit.motion.match.obj"
key = "m shift+/"
name = "comment ←"
combinedName = "comment →/←"
args.unit = "comment"
args.boundary = "both"
computedArgs.value = "-(count || 1)"
```
