### PR TITLE
Improve Larkin Bindings

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Master Key",
   "publisher": "haberdashPI",
   "description": "Master your keybindings with documentation, discoverability, modal bindings, macros and expressive configuration",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "icon": "logo.png",
   "repository": {
     "url": "https://github.com/haberdashPi/vscode-master-key"

--- a/presets/larkin.toml
+++ b/presets/larkin.toml
@@ -1304,7 +1304,7 @@ key = "m shift+0"
 name = "arn subsec ←"
 combinedName = "around subsection →/←"
 args.unit = "subsection"
-computedArgs.value = "count || 1"
+computedArgs.value = "-(count || 1)"
 
 [[bind]]
 path = "edit.motion.match.obj"
@@ -1321,7 +1321,7 @@ key = "m shift+9"
 name = "in subsec ←"
 combinedName = "in subsection →/←"
 args.unit = "subsection"
-computedArgs.value = "count || 1"
+computedArgs.value = "-(count || 1)"
 
 [[bind]]
 path = "edit.motion.match"
@@ -3158,12 +3158,8 @@ insert cursor on line above
 combinedDescription = "insert cursor on line above/below"
 key = "shift+k"
 combinedKey = "shift+k/j"
-command = "runCommands"
+command = "editor.action.insertCursorAbove"
 repeat = "count"
-args.commands = [
-      { command = "master-key.setMode", args = { value = "selectedit" } },
-      { command = "editor.action.insertCursorAbove" }
-]
 
 [[bind]]
 path = "edit.select_edit"
@@ -3173,12 +3169,8 @@ description = """
 insert cursor on line below
 """
 key = "shift+j"
-command = "runCommands"
+command = "editor.action.insertCursorBelow"
 repeat = "count-1"
-args.commands = [
-      { command = "master-key.setMode", args = { value = "selectedit" }},
-      { command = "editor.action.insertCursorBelow" }
-]
 
 [[bind]]
 path = "edit.select_edit"

--- a/presets/larkin.toml
+++ b/presets/larkin.toml
@@ -371,6 +371,7 @@ key = "shift+x"
 name = "exapand"
 description = "expand selections to full lines"
 command = "expandLineSelection"
+repeat = "count"
 
 [[path]]
 id = "edit.motion.obj"
@@ -613,6 +614,30 @@ key = "shift+r"
 name = "trim wht"
 description = "trim external whitespace"
 command = "selection-utilities.trimSelectionWhitespace"
+
+[[bind]]
+path = "edit.motion.obj"
+name = "→ num."
+description = "Move to next number"
+key = "shift+3"
+combinedName = "→/← num."
+combinedDescription = "Move to next/prev number"
+combinedKey = "shift+3/2"
+args.unit = "number"
+args.selectWhole = true
+args.boundary = "both"
+computedArgs.value = "(count || 1)"
+
+[[bind]]
+path = "edit.motion.obj"
+name = "← num."
+description = "Move to next number"
+key = "shift+2"
+combinedName = "→/← num."
+args.unit = "number"
+args.selectWhole = true
+args.boundary = "both"
+computedArgs.value = "-(count || 1)"
 
 [[bind]]
 path = "edit.motion"
@@ -1215,7 +1240,7 @@ key = "m e"
 name = "in subwrd"
 combinedName = "in → subword/word"
 combinedKey = "e/shift+e"
-args.unit = "subword"
+args.unit = "subident"
 args.boundary = "both"
 computedArgs.value = "count || 1"
 
@@ -3149,7 +3174,7 @@ insert cursor on line below
 """
 key = "shift+j"
 command = "runCommands"
-repeat = "count"
+repeat = "count-1"
 args.commands = [
       { command = "master-key.setMode", args = { value = "selectedit" }},
       { command = "editor.action.insertCursorBelow" }
@@ -3166,7 +3191,7 @@ mode if all selections are deleted.
 """
 key = "d"
 command = "selection-utilities.deletePrimary"
-repeat = 'count'
+repeat = "count-1"
 
 [[bind]]
 path = "edit.select_edit"


### PR DESCRIPTION
- add number motions (added to selection utilities 0.6.7)
- fix some section direction movements problems (some things that moved "backwards" didn't)
- allow additional commands to be repeated with a count
- clean up some unnecessary mode switch commands in `select_edit`
