### PR TITLE
update mode default resolution logic to overwrite, not merge

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Master Key",
   "publisher": "haberdashPI",
   "description": "Master your keybindings with documentation, discoverability, modal bindings, macros and expressive configuration",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "icon": "logo.png",
   "repository": {
     "url": "https://github.com/haberdashPi/vscode-master-key"

--- a/src/web/keybindings/processing.ts
+++ b/src/web/keybindings/processing.ts
@@ -20,11 +20,11 @@ import {
     pick,
     isEqual,
     omit,
-    mergeWith,
     cloneDeep,
     flatMap,
     mapValues,
     merge,
+    assignWith,
 } from 'lodash';
 import {reifyStrings, EvalContext} from '../expressions';
 import {isSingleCommand, validateInput, IIndexed} from '../utils';
@@ -78,17 +78,11 @@ function mapByName(specs: ModeSpec[]) {
     return modeSpecs;
 }
 
-function overwritePrefixesAndWhen(obj_: RawBindingItem, src_: RawBindingItem, key: string) {
-    if (key === 'prefixes' || key === 'when') {
-        if (src_ !== undefined) {
-            return src_;
-        } else {
-            return obj_;
-        }
-    } else {
-        // revert to default behavior
-        return;
+function mergeArgs(obj_: RawBindingItem, src_: RawBindingItem, key: string) {
+    if (key === 'args' || key === 'computedArgs') {
+        return merge(obj_, src_)
     }
+    return 
 }
 
 const runCommandsArgs = z.object({
@@ -157,7 +151,7 @@ function expandDefaultsDefinedAndForeach(
                 whens = cloneDeep(pathWhens[prefix]);
             }
         }
-        pathDefaults[path.id] = mergeWith(defaults, path.default, overwritePrefixesAndWhen);
+        pathDefaults[path.id] = assignWith(defaults, path.default, mergeArgs);
         if (path.when) {
             pathWhens[path.id] = whens.concat(path.when);
         }
@@ -170,7 +164,7 @@ function expandDefaultsDefinedAndForeach(
             problems.push(`The path '${item.path}' is undefined.`);
             return undefined;
         } else {
-            item = mergeWith(cloneDeep(itemDefault), item, overwritePrefixesAndWhen);
+            item = assignWith(cloneDeep(itemDefault), item, mergeArgs);
             if (item.when) {
                 item.when = itemConcatWhen ? item.when.concat(itemConcatWhen) : item.when;
             } else if (itemConcatWhen) {

--- a/src/web/keybindings/processing.ts
+++ b/src/web/keybindings/processing.ts
@@ -80,9 +80,9 @@ function mapByName(specs: ModeSpec[]) {
 
 function mergeArgs(obj_: RawBindingItem, src_: RawBindingItem, key: string) {
     if (key === 'args' || key === 'computedArgs') {
-        return merge(obj_, src_)
+        return merge(obj_, src_);
     }
-    return 
+    return;
 }
 
 const runCommandsArgs = z.object({

--- a/test/specs/config.ux.mts
+++ b/test/specs/config.ux.mts
@@ -352,7 +352,7 @@ describe('Configuration', () => {
             editor
         );
 
-        await enterModalKeys('ctrl+]');
+        await enterModalKeys(['ctrl', ']']);
 
         await movesCursorInEditor(
             async () => await enterModalKeys(['ctrl', 'h']),

--- a/test/specs/config.ux.mts
+++ b/test/specs/config.ux.mts
@@ -293,6 +293,75 @@ describe('Configuration', () => {
         expect(messages).toContainEqual(error);
     });
 
+    // eslint-disable-next-line no-restricted-properties
+    it.only('Can overwrite default mode', async () => {
+        await setBindings(`
+            [header]
+            name = "Debug Key Bindings"
+            version = "1.0"
+
+            [[mode]]
+            name = "a"
+            default = true
+
+            [[mode]]
+            name = "b"
+
+            [[bind]]
+            name = "mode a"
+            key = "ctrl+["
+            command = "setMode"
+            args = "a"
+
+            [[bind]]
+            name = "mode b"
+            key = "ctrl+]"
+            command = "setMode"
+            args = "b"
+
+            [[path]]
+            id = "actions"
+            name = "Actions"
+            default.mode = ["a", "b"]
+            default.args.to = "up"
+            default.args.select = false
+
+            [[bind]]
+            path = "actions"
+            key = "ctrl+h"
+            name = "x"
+            command = "cursorMove"
+            args = { to = "down"}
+            mode = ["a"]
+
+            [[bind]]
+            path = "actions"
+            key = "ctrl+h"
+            name = "x"
+            command = "cursorMove"
+            computedArgs = { select = true }
+            mode = ["b"]
+        `);
+
+        editor = await setupEditor('A simple test\nwith two lines');
+        await editor.moveCursor(1, 1);
+
+        await movesCursorInEditor(
+            async () => await enterModalKeys(['ctrl', 'h']),
+            [1, 0],
+            editor
+        );
+
+        await enterModalKeys('ctrl+]');
+
+        await movesCursorInEditor(
+            async () => await enterModalKeys(['ctrl', 'h']),
+            [-1, 0],
+            editor
+        );
+        expect(await editor.getSelectedText()).toEqual('A simple test\n');
+    });
+
     after(async () => {
         const workbench = await browser.getWorkbench();
         await workbench.executeCommand('Clear Command History');

--- a/test/specs/config.ux.mts
+++ b/test/specs/config.ux.mts
@@ -353,12 +353,7 @@ describe('Configuration', () => {
         );
 
         await enterModalKeys(['ctrl', ']']);
-
-        await movesCursorInEditor(
-            async () => await enterModalKeys(['ctrl', 'h']),
-            [-1, 0],
-            editor
-        );
+        await enterModalKeys(['ctrl', 'h']);
         expect(await editor.getSelectedText()).toEqual('A simple test\n');
     });
 

--- a/test/specs/config.ux.mts
+++ b/test/specs/config.ux.mts
@@ -310,14 +310,14 @@ describe('Configuration', () => {
             [[bind]]
             name = "mode a"
             key = "ctrl+["
-            command = "setMode"
-            args = "a"
+            command = "master-key.setMode"
+            args.value = "a"
 
             [[bind]]
             name = "mode b"
             key = "ctrl+]"
-            command = "setMode"
-            args = "b"
+            command = "master-key.setMode"
+            args.value = "b"
 
             [[path]]
             id = "actions"
@@ -353,6 +353,7 @@ describe('Configuration', () => {
         );
 
         await enterModalKeys(['ctrl', ']']);
+        await waitForMode('b');
         await enterModalKeys(['ctrl', 'h']);
         expect(await editor.getSelectedText()).toEqual('A simple test\n');
     });

--- a/test/specs/config.ux.mts
+++ b/test/specs/config.ux.mts
@@ -293,8 +293,7 @@ describe('Configuration', () => {
         expect(messages).toContainEqual(error);
     });
 
-    // eslint-disable-next-line no-restricted-properties
-    it.only('Can overwrite default mode', async () => {
+    it('Can overwrite default mode', async () => {
         await setBindings(`
             [header]
             name = "Debug Key Bindings"

--- a/wdio.conf.mts
+++ b/wdio.conf.mts
@@ -36,7 +36,7 @@ export const config: Options.Testrunner = {
     // The path of the spec files will be resolved relative from the directory of
     // of the config file unless it's absolute.
     //
-    specs: ['./test/specs/**/*.ux.mts'],
+    specs: ['./test/specs/**/config.ux.mts'],
     exclude: [
         // 'path/to/excluded/files'
     ],
@@ -71,8 +71,6 @@ export const config: Options.Testrunner = {
                 workspacePath: __dirname,
                 vscodeArgs: {
                     profile: 'debug-profile',
-                    'enable-features':
-                        'ConversionMeasurement,AttributionReportingCrossAppWeb',
                 },
                 storagePath: __dirname + '/.wdio-vscode-service/storage/',
             },

--- a/wdio.conf.mts
+++ b/wdio.conf.mts
@@ -36,7 +36,7 @@ export const config: Options.Testrunner = {
     // The path of the spec files will be resolved relative from the directory of
     // of the config file unless it's absolute.
     //
-    specs: ['./test/specs/**/config.ux.mts'],
+    specs: ['./test/specs/**/*.ux.mts'],
     exclude: [
         // 'path/to/excluded/files'
     ],


### PR DESCRIPTION
Fixes #34. I used the lodash functions instead of object splatting so I didn't have to deal with typing the function 😬. 

Tested with the following config to ensure that modes were overridden, but args / computed args were merged.

```toml
[header]
name = "Debug Key Bindings"
version = "1.0"

[[mode]]
name = "a"
default = true

[[mode]]
name = "b"

[[path]]
id = "actions"
name = "Actions"
default.mode = ["a", "b"]
default.args.to = "up"
default.args.select = false

[[bind]]
path = "actions"
key = "x"
name = "x"
command = "cursorMove"
args = { to = "down"}
mode = ["a"]

[[bind]]
path = "actions"
key = "x"
name = "x"
command = "cursorMove"
computedArgs = { select = true }
mode = ["b"]
```