### PR TITLE
Implement `fallbackBindings` for `mode` specification

### DIFF
--- a/src/web/keybindings/parsing.ts
+++ b/src/web/keybindings/parsing.ts
@@ -327,6 +327,7 @@ const modeSpec = z.object({
         .enum(['Line', 'Block', 'Underline', 'LineThin', 'BlockOutline', 'UnderlineThin'])
         .default('Line'),
     onType: doArgs.optional(),
+    fallbackBindings: z.string().optional().default(''),
     lineNumbers: z.enum(['relative', 'on', 'off', 'interval']).optional(),
 });
 export type ModeSpec = z.output<typeof modeSpec>;
@@ -385,6 +386,7 @@ export const bindingSpec = z
                         default: false,
                         recordEdits: false,
                         highlight: 'Highlight',
+                        fallbackBindings: '',
                     });
                 }
                 return xs;

--- a/src/web/keybindings/processing.ts
+++ b/src/web/keybindings/processing.ts
@@ -48,7 +48,7 @@ export function processBindings(spec: FullBindingSpec): [Bindings, string[]] {
     const docs = resolveDocItems(indexedItems, spec.doc || [], problems);
     let items = indexedItems.map((item, i) => requireTransientSequence(item, i, problems));
     items = expandPrefixes(items);
-    items = expandModes(items, spec.mode, problems);
+    items = expandModes(items, spec.mode, problems, spec.mode);
     items = expandDocsToDuplicates(items);
     const r = expandKeySequencesAndResolveDuplicates(items, problems);
     items = r[0];
@@ -467,8 +467,19 @@ function expandPrefixes(items: BindingItem[]) {
     });
 }
 
-function expandModes(items: BindingItem[], validModes: ModeSpec[], problems: string[]) {
+function expandModes(
+    items: BindingItem[],
+    validModes: ModeSpec[],
+    problems: string[],
+    modes: ModeSpec[],
+) {
     const defaultMode = validModes.filter(x => x.default)[0]; // validation should guarantee a single match
+    const fallbacks: Record<string, string> = {}
+    for (const mode of modes) {
+        if (mode.fallbackBindings) {
+            fallbacks[mode.fallbackBindings] = mode.name;
+        }
+    }
     return flatMap(items, (item: BindingItem): BindingItem[] => {
         let modes = item.mode || [defaultMode.name];
         if (modes.length > 0 && modes[0].startsWith('!')) {
@@ -483,6 +494,12 @@ function expandModes(items: BindingItem[], validModes: ModeSpec[], problems: str
             modes = validModes
                 .map(x => x.name)
                 .filter(mode => !exclude.some(x => x === mode));
+
+            const implicitModes: string[] = []
+            for (const mode of modes) {
+                let implicitMode = fallbacks[mode])
+
+            }
         }
         if (modes.length === 0) {
             return [item];

--- a/src/web/keybindings/processing.ts
+++ b/src/web/keybindings/processing.ts
@@ -481,33 +481,35 @@ function expandModes(
         }
     }
     return flatMap(items, (item: BindingItem): BindingItem[] => {
-        let modes = item.mode || [defaultMode.name];
-        if (modes.length > 0 && modes[0].startsWith('!')) {
-            if (modes.some(x => !x.startsWith('!'))) {
+        let itemModes = item.mode || [defaultMode.name];
+        if (itemModes.length > 0 && itemModes[0].startsWith('!')) {
+            if (itemModes.some(x => !x.startsWith('!'))) {
                 problems.push(
-                    `Either all or none of the modes for binding ${item.key} ` +
+                    `Either all or none of the itemModes for binding ${item.key} ` +
                         "must be prefixed with '!'"
                 );
-                modes = modes.filter(x => x.startsWith('!'));
+                itemModes = itemModes.filter(x => x.startsWith('!'));
             }
-            const exclude = modes.map(m => m.slice(1));
-            modes = validModes
+            const exclude = itemModes.map(m => m.slice(1));
+            itemModes = validModes
                 .map(x => x.name)
                 .filter(mode => !exclude.some(x => x === mode));
+        }
 
-            // add modes that are implicitly present due to fallbacks
-            const implicitModes: string[] = [];
-            for (const mode of modes) {
-                const implicitMode = fallbacks[mode];
-                if (implicitMode) {
-                    implicitModes.push(implicitMode);
-                }
+        // add modes that are implicitly present due to fallbacks
+        const implicitModes: string[] = [];
+        for (const mode of itemModes) {
+            const implicitMode = fallbacks[mode];
+            if (implicitMode) {
+                implicitModes.push(implicitMode);
             }
         }
-        if (modes.length === 0) {
+        itemModes = itemModes.concat(implicitModes);
+
+        if (itemModes.length === 0) {
             return [item];
         } else {
-            return modes.map(m => ({...item, mode: [m]}));
+            return itemModes.map(m => ({...item, mode: [m]}));
         }
     });
 }

--- a/src/web/keybindings/processing.ts
+++ b/src/web/keybindings/processing.ts
@@ -471,10 +471,10 @@ function expandModes(
     items: BindingItem[],
     validModes: ModeSpec[],
     problems: string[],
-    modes: ModeSpec[],
+    modes: ModeSpec[]
 ) {
     const defaultMode = validModes.filter(x => x.default)[0]; // validation should guarantee a single match
-    const fallbacks: Record<string, string> = {}
+    const fallbacks: Record<string, string> = {};
     for (const mode of modes) {
         if (mode.fallbackBindings) {
             fallbacks[mode.fallbackBindings] = mode.name;
@@ -495,10 +495,13 @@ function expandModes(
                 .map(x => x.name)
                 .filter(mode => !exclude.some(x => x === mode));
 
-            const implicitModes: string[] = []
+            // add modes that are implicitly present due to fallbacks
+            const implicitModes: string[] = [];
             for (const mode of modes) {
-                let implicitMode = fallbacks[mode])
-
+                const implicitMode = fallbacks[mode];
+                if (implicitMode) {
+                    implicitModes.push(implicitMode);
+                }
             }
         }
         if (modes.length === 0) {

--- a/test/specs/config.ux.mts
+++ b/test/specs/config.ux.mts
@@ -59,6 +59,26 @@ describe('Configuration', () => {
             name = "insert"
             key = "ctrl+i"
             command = "master-key.enterInsert"
+            mode = "normal"
+
+            [[bind]]
+            name = "normal-left mode"
+            key = "ctrl+u"
+            command = "master-key.setMode"
+            args.value = "normal-left"
+
+            [[mode]]
+            name = "normal-left"
+            fallbackBindings = "normal"
+
+            [[bind]]
+            path = "motion"
+            key = "ctrl+h"
+            mode = "normal-left"
+            name = "left"
+            when = "editorTextFocus"
+            command = "cursorMove"
+            args.to = "left"
         `);
 
         folder = fs.mkdtempSync(path.join(os.tmpdir(), 'master-key-test-'));
@@ -151,6 +171,17 @@ describe('Configuration', () => {
         const statusBarEl = await browser.$('div[aria-label="Keybinding Mode: insert"]');
         const statusBarClasses = await statusBarEl.getAttribute('class');
         expect(statusBarClasses).not.toMatch(/warning-kind/);
+    });
+
+    // eslint-disable-next-line no-restricted-properties
+    it.only('Can add fallback bindings', async () => {
+        await enterModalKeys(['ctrl', 'i']);
+        editor = await setupEditor('A simple test');
+        await enterModalKeys('escape');
+        await enterModalKeys(['ctrl', 'u']);
+        await waitForMode('normal-left');
+        await movesCursorInEditor(() => enterModalKeys(['ctrl', 'l']), [0, 1], editor);
+        await movesCursorInEditor(() => enterModalKeys(['ctrl', 'h']), [0, -1], editor);
     });
 
     it('Can be loaded from a directory', async () => {

--- a/test/specs/config.ux.mts
+++ b/test/specs/config.ux.mts
@@ -173,8 +173,7 @@ describe('Configuration', () => {
         expect(statusBarClasses).not.toMatch(/warning-kind/);
     });
 
-    // eslint-disable-next-line no-restricted-properties
-    it.only('Can add fallback bindings', async () => {
+    it('Can add fallback bindings', async () => {
         await enterModalKeys(['ctrl', 'i']);
         editor = await setupEditor('A simple test');
         await enterModalKeys('escape');

--- a/test/specs/config.ux.mts
+++ b/test/specs/config.ux.mts
@@ -174,8 +174,8 @@ describe('Configuration', () => {
     });
 
     it('Can add fallback bindings', async () => {
-        await enterModalKeys(['ctrl', 'i']);
         editor = await setupEditor('A simple test');
+        await enterModalKeys(['ctrl', 'i']);
         await enterModalKeys('escape');
         await enterModalKeys(['ctrl', 'u']);
         await waitForMode('normal-left');

--- a/test/specs/config.ux.mts
+++ b/test/specs/config.ux.mts
@@ -174,9 +174,9 @@ describe('Configuration', () => {
     });
 
     it('Can add fallback bindings', async () => {
-        editor = await setupEditor('A simple test');
-        await enterModalKeys(['ctrl', 'i']);
+        await editor.moveCursor(1, 1);
         await enterModalKeys('escape');
+        editor = await setupEditor('A simple test');
         await enterModalKeys(['ctrl', 'u']);
         await waitForMode('normal-left');
         await movesCursorInEditor(() => enterModalKeys(['ctrl', 'l']), [0, 1], editor);

--- a/wdio.conf.mts
+++ b/wdio.conf.mts
@@ -36,7 +36,7 @@ export const config: Options.Testrunner = {
     // The path of the spec files will be resolved relative from the directory of
     // of the config file unless it's absolute.
     //
-    specs: ['./test/specs/**/*.ux.mts'],
+    specs: ['./test/specs/**/config.ux.mts'],
     exclude: [
         // 'path/to/excluded/files'
     ],

--- a/wdio.conf.mts
+++ b/wdio.conf.mts
@@ -36,7 +36,7 @@ export const config: Options.Testrunner = {
     // The path of the spec files will be resolved relative from the directory of
     // of the config file unless it's absolute.
     //
-    specs: ['./test/specs/**/config.ux.mts'],
+    specs: ['./test/specs/**/*.ux.mts'],
     exclude: [
         // 'path/to/excluded/files'
     ],


### PR DESCRIPTION
This implements a `fallbackBinding` field. It can be set to the name of an existing mode. It causes any unspecified keys for the given mode fallback to the bindings provided in the fallback. A limitation of the current implementation is that to work properly, the bindings for this mode must be defined before the fallback bindings.
