### PR TITLE
Bugfix: `fallbackBIndings` creates duplicate bindings

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Master Key",
   "publisher": "haberdashPI",
   "description": "Master your keybindings with documentation, discoverability, modal bindings, macros and expressive configuration",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "icon": "logo.png",
   "repository": {
     "url": "https://github.com/haberdashPi/vscode-master-key"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Master Key",
   "publisher": "haberdashPI",
   "description": "Master your keybindings with documentation, discoverability, modal bindings, macros and expressive configuration",
-  "version": "0.3.10",
+  "version": "0.3.8",
   "icon": "logo.png",
   "repository": {
     "url": "https://github.com/haberdashPi/vscode-master-key"

--- a/src/web/keybindings/config.ts
+++ b/src/web/keybindings/config.ts
@@ -40,6 +40,22 @@ function fromZip64(str: string): string {
     return result || '';
 }
 
+export async function clearUserBindings() {
+    if (configState) {
+        const config = vscode.workspace.getConfiguration('master-key');
+        const storage = config.get<IStorage>('storage') || {};
+        storage.userBindings = undefined;
+        config.update('storage', storage, vscode.ConfigurationTarget.Global);
+        const newBindings: string = fromZip64(storage.presetBindings || '');
+        const newParsedBindings = processParsing(await parseBindings(newBindings));
+        if (newParsedBindings) {
+            bindings = newParsedBindings;
+            return newParsedBindings;
+        }
+    }
+    return undefined;
+}
+
 export async function createUserBindings(
     userBindings: string
 ): Promise<Bindings | undefined> {

--- a/src/web/keybindings/index.ts
+++ b/src/web/keybindings/index.ts
@@ -8,13 +8,13 @@ import {
     ParsedResult,
     ErrorResult,
 } from './parsing';
-import * as config from './config';
 import {processBindings, IConfigKeyBinding, Bindings} from './processing';
 import {isSingleCommand} from '../utils';
 import {uniq, pick} from 'lodash';
 import replaceAll from 'string.prototype.replaceall';
 import {Utils} from 'vscode-uri';
-import {createBindings, createUserBindings} from './config';
+import {clearUserBindings, createBindings, createUserBindings} from './config';
+import * as config from './config';
 const JSONC = require('jsonc-simple-parser');
 const TOML = require('smol-toml');
 
@@ -552,6 +552,13 @@ async function activateBindings(preset?: Preset) {
     }
 }
 
+async function deleteUserBindings() {
+    const bindings = await clearUserBindings();
+    if (bindings) {
+        insertKeybindingsIntoConfig(bindings);
+    }
+}
+
 async function selectUserBindings(file?: vscode.Uri) {
     if (!file) {
         const currentUri = vscode.window.activeTextEditor?.document.fileName;
@@ -648,6 +655,9 @@ export async function activate(context: vscode.ExtensionContext) {
     );
     context.subscriptions.push(
         vscode.commands.registerCommand('master-key.selectUserBindings', selectUserBindings)
+    );
+    context.subscriptions.push(
+        vscode.commands.registerCommand('master-key.removeUserBindings', deleteUserBindings)
     );
     context.subscriptions.push(
         vscode.commands.registerCommand('master-key.editPreset', copyBindingsToNewFile)

--- a/src/web/keybindings/parsing.ts
+++ b/src/web/keybindings/parsing.ts
@@ -287,7 +287,11 @@ export const bindingItem = z
         key: bindingKey,
         when: parsedWhen.array(),
         command: z.literal('master-key.do'),
-        mode: z.string().array().optional(),
+        mode: z
+            .string()
+            .or(z.object({implicit: z.string()}))
+            .array()
+            .optional(),
         prefixes: z.string().array().optional().default(['']),
         args: z
             .object({

--- a/test/specs/config.ux.mts
+++ b/test/specs/config.ux.mts
@@ -56,6 +56,13 @@ describe('Configuration', () => {
             args.to = "right"
 
             [[bind]]
+            path = "motion"
+            name = "double right"
+            key = "ctrl+shift+l"
+            args.to = "right"
+            computedArgs.value = 2
+
+            [[bind]]
             name = "insert"
             key = "ctrl+i"
             command = "master-key.enterInsert"
@@ -79,6 +86,14 @@ describe('Configuration', () => {
             when = "editorTextFocus"
             command = "cursorMove"
             args.to = "left"
+
+            [[bind]]
+            path = "motion"
+            name = "double left"
+            mode = "normal-left"
+            key = "ctrl+shift+l"
+            args.to = "left"
+            computedArgs.value = 2
         `);
 
         folder = fs.mkdtempSync(path.join(os.tmpdir(), 'master-key-test-'));
@@ -174,13 +189,25 @@ describe('Configuration', () => {
     });
 
     it('Can add fallback bindings', async () => {
-        await editor.moveCursor(1, 1);
         await enterModalKeys('escape');
         editor = await setupEditor('A simple test');
+        await editor.moveCursor(1, 1);
+        await movesCursorInEditor(
+            () => enterModalKeys(['ctrl', 'shift', 'l']),
+            [0, 2],
+            editor
+        );
         await enterModalKeys(['ctrl', 'u']);
         await waitForMode('normal-left');
         await movesCursorInEditor(() => enterModalKeys(['ctrl', 'l']), [0, 1], editor);
         await movesCursorInEditor(() => enterModalKeys(['ctrl', 'h']), [0, -1], editor);
+        await movesCursorInEditor(() => enterModalKeys(['ctrl', 'l']), [0, 1], editor);
+        await movesCursorInEditor(() => enterModalKeys(['ctrl', 'l']), [0, 1], editor);
+        await movesCursorInEditor(
+            () => enterModalKeys(['ctrl', 'shift', 'l']),
+            [0, -2],
+            editor
+        );
     });
 
     it('Can be loaded from a directory', async () => {

--- a/test/specs/config.ux.mts
+++ b/test/specs/config.ux.mts
@@ -273,8 +273,7 @@ describe('Configuration', () => {
         expect(modeItem).toBeTruthy();
     });
 
-    // eslint-disable-next-line no-restricted-properties
-    it('Can add user bindings', async () => {
+    it('Can add and remove user bindings', async () => {
         editor = await setupEditor('A simple test');
         const userFile = `
             [[bind]]
@@ -292,8 +291,11 @@ describe('Configuration', () => {
         const editorView = await workbench.getEditorView();
         const keyEditor = (await editorView.openEditor('keybindings.json')) as TextEditor;
         const keyText = await keyEditor.getText();
-        console.log('[DEBUG]: key text — ' + keyText);
         expect(keyText).toMatch(/"ctrl\+shift\+k"/);
+
+        await workbench.executeCommand('Master Key: Deactivate User Keybindings');
+        const removedKeyText = await keyEditor.getText();
+        expect(removedKeyText).not.toMatch(/"ctrl\+shift\+k"/);
     });
 
     it('Can be removed', async () => {

--- a/wdio.conf.mts
+++ b/wdio.conf.mts
@@ -36,7 +36,7 @@ export const config: Options.Testrunner = {
     // The path of the spec files will be resolved relative from the directory of
     // of the config file unless it's absolute.
     //
-    specs: ['./test/specs/**/*.ux.mts'],
+    specs: ['./test/specs/**/config.ux.mts'],
     exclude: [
         // 'path/to/excluded/files'
     ],

--- a/wdio.conf.mts
+++ b/wdio.conf.mts
@@ -36,7 +36,7 @@ export const config: Options.Testrunner = {
     // The path of the spec files will be resolved relative from the directory of
     // of the config file unless it's absolute.
     //
-    specs: ['./test/specs/**/config.ux.mts'],
+    specs: ['./test/specs/**/*.ux.mts'],
     exclude: [
         // 'path/to/excluded/files'
     ],


### PR DESCRIPTION
The last update lead to bugs with duplicate bindings, this addresses the problem by marking implicitly added bindings (via fallback). 

In addition this adds a missing command that started leading to problems in my testing: `Deactivate User Keybindings`.