### PR TITLE
Fix `setFlag` to work in `when` clauses

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Master Key",
   "publisher": "haberdashPI",
   "description": "Master your keybindings with documentation, discoverability, modal bindings, macros and expressive configuration",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "icon": "logo.png",
   "repository": {
     "url": "https://github.com/haberdashPi/vscode-master-key"

--- a/src/web/state.ts
+++ b/src/web/state.ts
@@ -300,7 +300,9 @@ const setFlagArgs = z
 async function setFlag(args_: unknown): Promise<CommandResult> {
     const args = validateInput('master-key.setFlag', args_, setFlagArgs);
     if (args) {
-        const opt = !args.transient ? {} : {transient: {reset: false}};
+        const opt: ISetOptions = !args.transient
+            ? {public: true}
+            : {public: true, transient: {reset: false}};
         const a = args;
         await withState(async state => {
             return state.set(a.name, opt, a.value);


### PR DESCRIPTION
Closes #42. 

This adds no additional tests, `setFlag` test are slated forUX tests in #18, and have now been bumped up in priority.
