### PR TITLE
Eliminate `lineNumbers` mode option

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ If you want to improve your text editing super powers in VSCode, Master Key migh
 > [!NOTE]
 > To power users: Master Key was envisioned as a set of tools to make it easy to create powerful keybinding specifications that match your editor style of choice (modal, chorded, etc...). There are currently some limitations, noted in [Keybinding Features](#keybinding-features) and [Customized Bindings](#customized-bindings) when creating custom binding sets.
 
+> [!WARN]
+> The most recent versions of Master Key have disabled the feature allowing the user to to modify how line numbers are set in different modes. This feature depended on a bit of a hack and in recent versions of VSCode this hack no longer works; to avoid buggy cursor motion this feature is currently disabled until a better solution can be provided by upstream.
+
 ## To get started
 
 The easiest way to get started is to activate the built-in keybindings that come with Master Key.

--- a/mise.toml
+++ b/mise.toml
@@ -1,2 +1,3 @@
 [tools]
 node = "20"
+"npm:vsce" = "latest"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Master Key",
   "publisher": "haberdashPI",
   "description": "Master your keybindings with documentation, discoverability, modal bindings, macros and expressive configuration",
-  "version": "0.3.15",
+  "version": "0.3.16",
   "icon": "logo.png",
   "repository": {
     "url": "https://github.com/haberdashPi/vscode-master-key"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Master Key",
   "publisher": "haberdashPI",
   "description": "Master your keybindings with documentation, discoverability, modal bindings, macros and expressive configuration",
-  "version": "0.3.14",
+  "version": "0.3.15",
   "icon": "logo.png",
   "repository": {
     "url": "https://github.com/haberdashPi/vscode-master-key"

--- a/presets/larkin.toml
+++ b/presets/larkin.toml
@@ -41,7 +41,6 @@ requiredExtensions = [
 
 [[mode]]
 name = "insert"
-lineNumbers = "on"
 recordEdits = true
 
 [[mode]]
@@ -49,13 +48,11 @@ name = "normal"
 default = true
 highlight = "Highlight"
 cursorShape = "Block"
-lineNumbers = "relative"
 
 [[mode]]
 name = "selectedit"
 highlight = "Highlight"
 cursorShape = "BlockOutline"
-lineNumbers = "relative"
 
 [define]
 select_on = false
@@ -3390,7 +3387,6 @@ command = "selection-utilities.activeAtStart"
 name = "syminsert"
 highlight = "Highlight"
 cursorShape = "BlockOutline"
-lineNumbers = "relative"
 
 [[mode.onType]]
 command = "selection-utilities.insertAround"

--- a/src/web/commands/mode.ts
+++ b/src/web/commands/mode.ts
@@ -37,11 +37,14 @@ async function updateModeKeyCapture(mode: string, modeSpec: Record<string, ModeS
 function updateLineNumbers(mode: string, modeSpec: Record<string, ModeSpec>) {
     const config = vscode.workspace.getConfiguration();
     const numbers = modeSpec[mode]?.lineNumbers || defaultLineNumbers;
-    config.update(
-        'editor.lineNumbers',
-        numbers || defaultLineNumbers,
-        vscode.ConfigurationTarget.Global
-    );
+    // TODO: currently I just disable this behavior as it causes the cursor to
+    // move around unexpectedly. I will need to remove all of the code covering
+    // this behavior in a future release
+    // config.update(
+    //     'editor.lineNumbers',
+    //     numbers || defaultLineNumbers,
+    //     vscode.ConfigurationTarget.Global
+    // );
 }
 
 const setModeArgs = z.object({value: z.string()}).strict();

--- a/src/web/commands/mode.ts
+++ b/src/web/commands/mode.ts
@@ -34,19 +34,6 @@ async function updateModeKeyCapture(mode: string, modeSpec: Record<string, ModeS
     runCommandOnKeys(modeSpec[mode]?.onType, mode);
 }
 
-function updateLineNumbers(mode: string, modeSpec: Record<string, ModeSpec>) {
-    const config = vscode.workspace.getConfiguration();
-    const numbers = modeSpec[mode]?.lineNumbers || defaultLineNumbers;
-    // TODO: currently I just disable this behavior as it causes the cursor to
-    // move around unexpectedly. I will need to remove all of the code covering
-    // this behavior in a future release
-    // config.update(
-    //     'editor.lineNumbers',
-    //     numbers || defaultLineNumbers,
-    //     vscode.ConfigurationTarget.Global
-    // );
-}
-
 const setModeArgs = z.object({value: z.string()}).strict();
 async function setMode(args_: unknown): Promise<CommandResult> {
     const args = validateInput('master-key.setMode', args_, setModeArgs);
@@ -65,19 +52,8 @@ async function updateModeSpecs(bindings: Bindings | undefined) {
     await withState(async state => state.set(MODE, {public: true}, defaultMode).resolve());
 }
 
-let defaultLineNumbers: string = 'on';
-async function updateLineNumConfig(event?: vscode.ConfigurationChangeEvent) {
-    if (!event || event?.affectsConfiguration('master-key')) {
-        const config = vscode.workspace.getConfiguration('master-key');
-        defaultLineNumbers = config.get<string>('defaultLineNumbers') || 'on';
-    }
-}
-
 let currentMode = 'default';
 export async function activate(context: vscode.ExtensionContext) {
-    await updateLineNumConfig();
-    vscode.workspace.onDidChangeConfiguration(updateLineNumConfig);
-
     onChangeBindings(updateModeSpecs);
 
     vscode.window.onDidChangeActiveTextEditor(e => {
@@ -114,7 +90,6 @@ export async function activate(context: vscode.ExtensionContext) {
                 modeSpecs || {}
             );
             updateModeKeyCapture(newMode, modeSpecs || {});
-            updateLineNumbers(newMode, modeSpecs || {});
             currentMode = newMode;
         }
         return true;

--- a/src/web/keybindings/parsing.ts
+++ b/src/web/keybindings/parsing.ts
@@ -332,7 +332,6 @@ const modeSpec = z.object({
         .default('Line'),
     onType: doArgs.optional(),
     fallbackBindings: z.string().optional().default(''),
-    lineNumbers: z.enum(['relative', 'on', 'off', 'interval']).optional(),
 });
 export type ModeSpec = z.output<typeof modeSpec>;
 


### PR DESCRIPTION
Changing how `lineNumbers` are displayed per mode seemed to work well in older version of VSCode, but it is now causing unexpected cursor movement whenever the mode is switched. This is a pretty unacceptable problem for day-to-day use, so I'm removing this feature for now. If at some point VSCode makes it possible to change line number display without changing the config file, I can reconsider adding this feature.