### PR TITLE
`master-key.prefix` can transiently change cursor style

### DIFF
--- a/src/web/commands/prefix.ts
+++ b/src/web/commands/prefix.ts
@@ -1,13 +1,15 @@
 import * as vscode from 'vscode';
 import z from 'zod';
-import {validateInput} from '../utils';
-import {recordedCommand, CommandState, CommandResult, withState} from '../state';
+import {CURSOR_SHAPES, CursorShape, updateCursorAppearance, validateInput} from '../utils';
+import {recordedCommand, CommandState, CommandResult, withState, onSet} from '../state';
 import {PrefixCodes} from '../keybindings/processing';
+import {restoreModesCursorState} from './mode';
 
 const prefixArgs = z
     .object({
         code: z.number(),
         flag: z.string().min(1).endsWith('_on').optional(),
+        cursor: z.enum(CURSOR_SHAPES).optional(),
         // `automated` is used during keybinding preprocessing and is not normally used otherwise
         automated: z.boolean().optional(),
     })
@@ -16,6 +18,7 @@ const prefixArgs = z
 export const PREFIX_CODE = 'prefixCode';
 export const PREFIX_CODES = 'prefixCodes';
 export const PREFIX = 'prefix';
+const PREFIX_CURSOR = 'prefixCursor';
 
 // HOLD ON!! this feels broken — really when the prefix codes get LOADED
 // we should translate them into the proper type of object
@@ -35,6 +38,7 @@ export function prefixCodes(state: CommandState): [CommandState, PrefixCodes] {
     return [state, prefixCodes];
 }
 
+let oldPrefixCursor: boolean = false;
 async function prefix(args_: unknown): Promise<CommandResult> {
     const args = validateInput('master-key.prefix', args_, prefixArgs);
     if (args !== undefined) {
@@ -49,6 +53,12 @@ async function prefix(args_: unknown): Promise<CommandResult> {
 
                 if (a.flag) {
                     state.set(a.flag, {transient: {reset: false}, public: true}, true);
+                }
+                if (a.cursor) {
+                    const cursorShape = <CursorShape>a.cursor;
+                    state.set(PREFIX_CURSOR, {transient: {reset: false}}, true);
+                    oldPrefixCursor = true;
+                    updateCursorAppearance(vscode.window.activeTextEditor, cursorShape);
                 }
             });
         });
@@ -74,4 +84,11 @@ export async function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(
         vscode.commands.registerCommand('master-key.prefix', recordedCommand(prefix))
     );
+
+    await onSet(PREFIX_CURSOR, state => {
+        if (!state.get(PREFIX_CURSOR, false) && oldPrefixCursor) {
+            restoreModesCursorState();
+        }
+        return true;
+    });
 }

--- a/src/web/status/keyseq.ts
+++ b/src/web/status/keyseq.ts
@@ -8,7 +8,7 @@ import {normalizeLayoutIndependentString} from '../keybindings/layout';
 
 let keyStatusBar: vscode.StatusBarItem | undefined = undefined;
 
-const KEY_DISPLAY_DELAY_DEFAULT = process.env.TESTING ? 180 : 500;
+const KEY_DISPLAY_DELAY_DEFAULT = 500;
 let keyDisplayDelay: number = KEY_DISPLAY_DELAY_DEFAULT;
 let statusUpdates = Number.MIN_SAFE_INTEGER;
 

--- a/src/web/utils.ts
+++ b/src/web/utils.ts
@@ -90,3 +90,39 @@ export function get<T extends object, K extends keyof T>(x: T, key: K, def: T[K]
         return def;
     }
 }
+
+export const CURSOR_STYLES = {
+    Line: vscode.TextEditorCursorStyle.Line,
+    Block: vscode.TextEditorCursorStyle.Block,
+    Underline: vscode.TextEditorCursorStyle.Underline,
+    LineThin: vscode.TextEditorCursorStyle.LineThin,
+    BlockOutline: vscode.TextEditorCursorStyle.BlockOutline,
+    UnderlineThin: vscode.TextEditorCursorStyle.UnderlineThin,
+};
+
+export const CURSOR_SHAPES: [string, ...string[]] = [
+    'Line',
+    'Block',
+    'Underline',
+    'LineThin',
+    'BlockOutline',
+    'UnderlineThin',
+];
+
+export type CursorShape =
+    | 'Line'
+    | 'Block'
+    | 'Underline'
+    | 'LineThin'
+    | 'BlockOutline'
+    | 'UnderlineThin';
+
+export function updateCursorAppearance(
+    editor: vscode.TextEditor | undefined,
+    cursorShape: CursorShape
+) {
+    if (editor) {
+        editor.options.cursorStyle =
+            CURSOR_STYLES[cursorShape] || vscode.TextEditorCursorStyle.Line;
+    }
+}

--- a/test/specs/commandState.ux.mts
+++ b/test/specs/commandState.ux.mts
@@ -236,9 +236,9 @@ describe('Command State', () => {
         await enterModalKeys(['ctrl', 'shift', 'd'], ['ctrl', 'e']);
         expect(await editor.getText()).toEqual(' is a short, simple sentence');
 
+        await sleep(250);
+        await browser.keys([Key.Ctrl, Key.Shift, 'd']);
         await sleep(1000);
-        await enterModalKeys({key: ['ctrl', 'shift', 'd'], updatesStatus: false});
-        await waitForKeysTyped('^⇧D');
         const cursorEl = await browser.$('div[role="presentation"].cursors-layer');
         const cursorClasses = await cursorEl.getAttribute('class');
         expect(cursorClasses).toMatch(/cursor-underline-style/);

--- a/test/specs/commandState.ux.mts
+++ b/test/specs/commandState.ux.mts
@@ -1,12 +1,15 @@
 // start with just some basic tests to verify all is well
 
 import {browser, expect} from '@wdio/globals';
+import {Key} from 'webdriverio';
 import {
     setBindings,
     setupEditor,
     movesCursorInEditor,
     enterModalKeys,
     storeCoverageStats,
+    waitForClearedKeyStatus,
+    waitForKeysTyped,
 } from './utils.mts';
 import 'wdio-vscode-service';
 import {sleep, TextEditor} from 'wdio-vscode-service';
@@ -105,6 +108,7 @@ describe('Command State', () => {
 
             [[bind.args.commands]]
             command = "master-key.prefix"
+            args.cursor = "Underline"
 
             [[bind.args.commands]]
             command = "master-key.storeCommand"
@@ -231,6 +235,25 @@ describe('Command State', () => {
         await sleep(1000);
         await enterModalKeys(['ctrl', 'shift', 'd'], ['ctrl', 'e']);
         expect(await editor.getText()).toEqual(' is a short, simple sentence');
+
+        await sleep(1000);
+        await enterModalKeys({key: ['ctrl', 'shift', 'd'], updatesStatus: false});
+        await waitForKeysTyped('^⇧D');
+        const cursorEl = await browser.$('div[role="presentation"].cursors-layer');
+        const cursorClasses = await cursorEl.getAttribute('class');
+        expect(cursorClasses).toMatch(/cursor-underline-style/);
+
+        await sleep(2000);
+        browser.keys([Key.Control, 'e']);
+        await waitForClearedKeyStatus([
+            ['ctrl', 'shift', 'd'],
+            ['ctrl', 'e'],
+        ]);
+        const cursorEl2 = await browser.$('div[role="presentation"].cursors-layer');
+        const cursorClasses2 = await cursorEl2.getAttribute('class');
+        expect(cursorClasses2).toMatch(/cursor-line-style/);
+
+        expect(await editor.getText()).toEqual(' a short, simple sentence');
     });
 
     after(async () => {

--- a/test/specs/palette.ux.mts
+++ b/test/specs/palette.ux.mts
@@ -156,7 +156,8 @@ describe('Palette', () => {
         expect(picks).toHaveLength(1);
 
         await browser.keys(Key.Escape);
-        await browser.keys('p');
+        await sleep(1000);
+        await enterModalKeys('p');
         await enterModalKeys('i');
         await sleep(1000);
     });

--- a/test/specs/searchMotions.ux.mts
+++ b/test/specs/searchMotions.ux.mts
@@ -523,8 +523,8 @@ labore elit occaecat cupidatat non POINT_B.`);
     });
 
     after(async () => {
-        await enterModalKeys('escape');
-        await enterModalKeys(['shift', 'i']);
+        await browser.keys('escape');
+        await browser.keys([Key.Shift, 'i']);
         await storeCoverageStats('searchMotion');
     });
 });

--- a/test/specs/utils.mts
+++ b/test/specs/utils.mts
@@ -238,10 +238,12 @@ export async function waitForClearedKeyStatus(
 }
 
 export async function waitForKeysTyped(
+    keyCodes: string[],
     currentKeySeqString: string,
     workbench?: Workbench,
     statusBar?: StatusBar
 ) {
+    browser.keys(keyCodes);
     workbench = workbench || (await browser.getWorkbench());
     statusBar = statusBar || (await new StatusBar(workbench.locatorMap));
     const waitOpts = {interval: 10, timeout: 10_000};
@@ -299,10 +301,10 @@ export async function enterModalKeys(...keySeq: ModalKey[]) {
 
         // we do *NOT* await here, so that we can catch display events that are fast
         await sleep(50);
-        browser.keys(keyCodes);
         if (modalKeyUpdateStatus(keys_)) {
-            await waitForKeysTyped(currentKeySeqString, workbench, statusBar);
+            await waitForKeysTyped(keyCodes, currentKeySeqString, workbench, statusBar);
         } else {
+            browser.keys(keyCodes);
             checkCleared = false;
         }
     }


### PR DESCRIPTION
Closes #55 

TODO:

- [ ] ~~Wait for March 1st to be able to run more CI tests~~
- [x] seemingly unrelated tests are failing