### PR TITLE
bugfix: delayed update of count-status

### DIFF
--- a/src/extension/state.ts
+++ b/src/extension/state.ts
@@ -99,9 +99,6 @@ export class CommandState {
         }
 
         if (this.get(key, opt) !== val) {
-            const listeners = this.setListeners[fullKey] || [];
-            this.setListeners[fullKey] = listeners.filter(listener => listener(val));
-
             try {
                 if (!opt.__dont_update_bindings__) {
                     bindings.set_value(namespace, key, val);
@@ -137,6 +134,8 @@ export class CommandState {
                     );
                 }
             }
+            const listeners = this.setListeners[fullKey] || [];
+            this.setListeners[fullKey] = listeners.filter(listener => listener(val));
         }
     }
 


### PR DESCRIPTION
Pressing a number in Larkin did not update the status bar until the *next* keypress. This happened because of a more general bug where listeners were updated *before* the new state is set. This is usually okay because we pass the new value in as a variable, but in cases where we need to indirectly access state using `get` the assumptions of a listener can fail.