### PR TITLE
document `[[kind]]`

### DIFF
--- a/docs/.simple-src-docs.config.toml
+++ b/docs/.simple-src-docs.config.toml
@@ -92,7 +92,7 @@ output = """
 """
 
 [[template.foreach]]
-tags = ["bindingField", "description"]
+tags = ["bindingField"]
 file = "bindings/{{bindingField}}.md"
 output = """
 

--- a/mise.toml
+++ b/mise.toml
@@ -164,7 +164,11 @@ run = 'pnpm exec playwright test'
 [tasks.extract-docs]
 sources = ['README.md', 'src/extension/**/*.ts', 'src/rust/**/*.rs', 'src/docs/**/*.md']
 outputs = ['docs/**/*.md']
-run = ['simple-src-docs -d docs src README.md', 'cp src/docs/index.md docs/']
+shell = 'nu -c'
+run = [
+    'simple-src-docs -d docs src/extension/**/*.ts src/rust/**/*.rs src/docs/**/*.md README.md',
+    'cp src/docs/index.md docs/',
+]
 
 [tasks.extract-preset-docs]
 sources = ['../../presets/**/*.toml', 'src/**/*.rs']

--- a/src/rust/parsing/src/bind.rs
+++ b/src/rust/parsing/src/bind.rs
@@ -59,6 +59,7 @@ where
 
 /// @bindingField bind
 /// @description an actual keybinding; extends the schema used by VSCode's `keybindings.json`
+/// @order 10
 ///
 /// **Example**
 ///

--- a/src/rust/parsing/src/kind.rs
+++ b/src/rust/parsing/src/kind.rs
@@ -10,7 +10,8 @@ use crate::error::{ErrorContext, ParseError, Result, ResultVec};
 use crate::expression::Scope;
 use crate::{err, wrn};
 
-/// @forBindingField kind
+/// @bindingField kind
+/// @description a category used to visually label keybindings
 ///
 /// Kind is a broad category for keybindings that is displayed as part of the visual
 /// documentation for key bindings. There should be no more than 5 or so kinds, since they are


### PR DESCRIPTION
Some formatting issues prevented `kind` from being a part of the documentation