### PR TITLE
Bugfix: properly handle explicit prefixes in the display and recording of bindings.

### DIFF
--- a/notes.md
+++ b/notes.md
@@ -39,9 +39,9 @@ want to replace `Span` with something like `(Source, Span)`
     - [X] fix `last_history_index` return error bug
         - [X] add unit tests to ensure we can add integers to `last_history_index` output
         - [X] split into small patch fix PR
-    - [ ] fix `finalKey = false` grouping bug
-        - [~] add integration tests to ensure `finalKey = false` bindings get grouped
-        - [ ] unit test for merged reified bindings
+    - [X] fix `finalKey = false` grouping bug
+        - [X] add integration tests to ensure `finalKey = false` bindings get grouped
+        - [X] unit test for merged reified bindings
         - [X] split into small patch fix PR
     - [ ] add repeat action to the vim.toml bindings (after fixing the bugs above)
 

--- a/package.json
+++ b/package.json
@@ -132,6 +132,11 @@
                 "title": "Toggle Key Suggestions"
             },
             {
+                "command": "master-key.toggleSuggestionsInAuxiliarySidebar",
+                "category": "Master Key",
+                "title": "Toggle Key Suggestions (Auxiliary Sidebar)"
+            },
+            {
                 "command": "master-key.showVisualDoc",
                 "category": "Master Key",
                 "title": "Show Visual Documentation"

--- a/src/extension/commands/do.ts
+++ b/src/extension/commands/do.ts
@@ -147,6 +147,7 @@ export const commandMutex = new Mutex();
 export async function doCommandsCmd(args_: unknown): Promise<CommandResult> {
     // see extension-profiles/README.md for details
     // console.profile('master-key-do');
+
     // register that a key was pressed (cancelling the display of the quick pick for
     // prefixes of this keypress
     registerKeyPress();

--- a/src/extension/commands/palette.ts
+++ b/src/extension/commands/palette.ts
@@ -334,7 +334,16 @@ export async function defineCommands(context: vscode.ExtensionContext) {
      * @name Toggle Key Suggestions
      *
      * Display or hide a list of possible key presses which follow from the current prefix
-     * of keys pressed so far.
+     * of keys pressed so far. Assumes the primary sidebar is used to display the bindings
+     * (the bar on the left side).
+     *
+     * When hidden, this makes the binding visible. When already visible, this command hides
+     * the sidebar, which is where the key suggestions are placed by default.
+     *
+     * Extensions do not control where tree views show up. The user is able to explicitly
+     * move these views around as they see fit, and Master Key has no visibility into this
+     * choice. Users wishing to keep the key suggestions in the right pane, can use the
+     * command `master-key.toggleSuggestionsInAuxiliaryBar`.
      */
     context.subscriptions.push(
         vscode.commands.registerCommand('master-key.toggleSuggestions', async () => {
@@ -344,6 +353,36 @@ export async function defineCommands(context: vscode.ExtensionContext) {
                 await commandPalette();
             }
         }),
+    );
+
+    /**
+     * @userCommand toggleSuggestionsInAuxiliaryBar
+     * @name Toggle Key Suggestions
+     *
+     * Display or hide a list of possible key presses which follow from the current prefix
+     * of keys pressed so far. Assumes the auxiliary sidebar is used to display the bindings
+     * (the bar on the right side).
+     *
+     * When hidden, this makes the binding visible. When already visible, this command hides
+     * the auxiliary sidebar. Users wishing to use this command to toggle suggestions should
+     * first move the key suggestions over to the auxiliary bar.
+     *
+     * Extensions do not control where tree views show up. The user is able to explicitly
+     * move these views around as they see fit, and Master Key has no visibility into this
+     * choice. Users wishing to keep the key suggestions in the left pane, can use the
+     * command `master-key.toggleSuggestions`.
+     */
+    context.subscriptions.push(
+        vscode.commands.registerCommand('master-key.toggleSuggestionsInAuxiliaryBar',
+            async () => {
+                if (treeView.visible) {
+                    await vscode.commands.executeCommand(
+                        'workbench.action.toggleAuxiliaryBar',
+                    );
+                } else {
+                    await commandPalette();
+                }
+            }),
     );
 
     // Command to handle clicking an item in the tree

--- a/src/presets/larkin.toml
+++ b/src/presets/larkin.toml
@@ -2441,7 +2441,7 @@ command = "git.revertSelectedRanges"
 
 [[bind]]
 default = "{{bind.util}}"
-doc.name = "revert range"
+doc.name = "stage range"
 doc.description = "stage changes in selected range"
 key = "tab g s"
 command = "git.stageSelectedRanges"

--- a/src/rust/parsing/src/bind.rs
+++ b/src/rust/parsing/src/bind.rs
@@ -2439,6 +2439,54 @@ mod tests {
         assert!(err.to_string().contains("default must"));
     }
 
+    #[test]
+    fn test_reified_binding_merge() {
+        let binding1 = ReifiedBinding {
+            error: Some(vec!["error1".to_string()]),
+            finalKey: false,
+            key: "ctrl+k".to_string(),
+            raw_commands: Vec::new(),
+            commands: Vec::new(),
+            mode: "normal".to_string(),
+            repeat: 1,
+            tags: vec![Dynamic::from("tag1".to_string())],
+            doc: BindingDoc::default(),
+            edit_document_id: 10,
+            edit_text: "edit1".to_string(),
+        };
+
+        let binding2 = ReifiedBinding {
+            error: Some(vec!["error2".to_string()]),
+            finalKey: true,
+            key: "ctrl+j".to_string(),
+            raw_commands: Vec::new(),
+            commands: Vec::new(),
+            mode: "insert".to_string(),
+            repeat: 2,
+            tags: vec![Dynamic::from("tag2".to_string())],
+            doc: BindingDoc {
+                name: "merged_doc".to_string(),
+                ..BindingDoc::default()
+            },
+            edit_document_id: 20,
+            edit_text: "edit2".to_string(),
+        };
+
+        let merged = binding1.merge(&binding2);
+
+        assert_eq!(merged.error, Some(vec!["error1".to_string(), "error2".to_string()]));
+        assert_eq!(merged.finalKey, true);
+        assert_eq!(merged.key, "ctrl+k ctrl+j");
+        assert_eq!(merged.mode, "insert");
+        assert_eq!(merged.repeat, 2);
+        assert_eq!(merged.tags.len(), 2);
+        assert_eq!(merged.tags[0].clone().into_string().unwrap(), "tag1");
+        assert_eq!(merged.tags[1].clone().into_string().unwrap(), "tag2");
+        assert_eq!(merged.doc.name, "merged_doc");
+        assert_eq!(merged.edit_document_id, 20);
+        assert_eq!(merged.edit_text, "edit1edit2");
+    }
+
     // TODO: are there any edge cases / failure modes I want to look at in the tests
     // (most of the things seem likely to be covered by serde / toml parsing, and the
     // stuff I would want to check should be done at a higher level when I'm working

--- a/src/rust/parsing/src/define.rs
+++ b/src/rust/parsing/src/define.rs
@@ -451,6 +451,7 @@ mod tests {
         let mut warnings = Vec::new();
         let result = Define::new(
             toml::from_str::<DefineInput>(data).unwrap(),
+            None,
             &mut scope,
             &mut warnings,
             &semver::Version::parse("2.1.0").unwrap(),

--- a/src/rust/parsing/src/define.rs
+++ b/src/rust/parsing/src/define.rs
@@ -451,7 +451,6 @@ mod tests {
         let mut warnings = Vec::new();
         let result = Define::new(
             toml::from_str::<DefineInput>(data).unwrap(),
-            None,
             &mut scope,
             &mut warnings,
             &semver::Version::parse("2.1.0").unwrap(),


### PR DESCRIPTION
Explicit prefixes are those prefixes which are triggered by one binding executing `master-key.prefix` and another binding following up on the prefix that was set by the first binding using the explicit `prefixes` field of `[[bind]]`.

In essense two separate keybindings behave as a single key sequence in this scenario.

The curent code misses some edge cases in properly handling these more complex bindings.

Display: the old code wouldn't show the explicit prefix of a binding. So for example `d w` in vim.toml would show up as `d` and then, when the user pressed `w`, the status bar would erase the `d` and show `w` in isolation. The desired behavior is to show `d, w` in the status bar when `w` is hit.

Command history: likewise these two separate bindings would show up as two distinct entries in the command history. Even though conceptually they behave as a single keybinding sequence.

Closes #166