### PR TITLE
Improve reliability of press-replay-binding.test.ts

### DIFF
--- a/src/test/integration/press-replay-bindings.test.ts
+++ b/src/test/integration/press-replay-bindings.test.ts
@@ -2,6 +2,20 @@ import { test, expect } from './config';
 import { activateKeybindings, openFile } from './utils';
 import { Page } from '@playwright/test';
 
+async function macroIsRecording(workbox: Page) {
+    const statusBarMode = workbox.locator(
+        'div[aria-label="Keybinding Mode: rec: normal"]',
+    );
+    await expect(statusBarMode).toHaveClass(/error-kind/);
+}
+
+async function macroIsNotRecording(workbox: Page) {
+    const statusBarMode = workbox.locator(
+        'div[aria-label="Keybinding Mode: normal"]',
+    );
+    await expect(statusBarMode).toBeAttached();
+}
+
 test.describe('Recorded keypresses', () => {
     async function setup(workbox: Page) {
         await activateKeybindings(workbox, 'replayMotions.toml');
@@ -21,10 +35,15 @@ test.describe('Recorded keypresses', () => {
     test('Handles basic recording', async ({ workbox }) => {
         const { editor, pos } = await setup(workbox);
         await editor.press('Shift+q');
+        macroIsRecording(workbox);
+
         await editor.press('l');
         await editor.press('j');
         await expect(pos).toHaveText('Ln 2, Col 2');
+
         await editor.press('Shift+q');
+        macroIsNotRecording(workbox);
+
         await editor.press('q');
         await editor.press('q');
         await expect(pos).toHaveText('Ln 3, Col 3');
@@ -57,10 +76,14 @@ test.describe('Recorded keypresses', () => {
             const { editor, pos } = await setup(workbox);
 
             await editor.press('Shift+q');
+            macroIsRecording(workbox);
+
             await editor.press('Shift+3');
             await editor.press('l');
             await expect(pos).toHaveText('Ln 1, Col 4');
             await editor.press('Shift+q');
+            macroIsNotRecording(workbox);
+
             await editor.press('q');
             await editor.press('q');
             await expect(pos).toHaveText('Ln 1, Col 7');
@@ -71,12 +94,16 @@ test.describe('Recorded keypresses', () => {
         test('Replays search', async ({ workbox }) => {
             const { editor, pos } = await setup(workbox);
             await editor.press('Shift+q');
+            macroIsRecording(workbox);
+
             await editor.press('/');
             const search = workbox.getByRole('textbox', { name: 'Search' });
             await search.pressSequentially('c d');
             await search.press('Enter');
             await expect(pos).toHaveText('Ln 1, Col 4');
             await editor.press('Shift+q');
+            macroIsNotRecording(workbox);
+
             await editor.press('Shift+3');
             await editor.press('h');
             await editor.press('q');
@@ -89,10 +116,14 @@ test.describe('Recorded keypresses', () => {
         test('Replays search with `acceptAfter`', async ({ workbox }) => {
             const { editor, pos } = await setup(workbox);
             await editor.press('Shift+q');
+            macroIsRecording(workbox);
+
             await editor.press('t');
             await editor.press('c');
             await expect(pos).toHaveText('Ln 1, Col 4');
             await editor.press('Shift+q');
+            macroIsNotRecording(workbox);
+
             await editor.press('Shift+3');
             await editor.press('h');
             await editor.press('q');
@@ -105,12 +136,16 @@ test.describe('Recorded keypresses', () => {
         test('Replays search with canceled input', async ({ workbox }) => {
             const { editor, pos } = await setup(workbox);
             await editor.press('Shift+q');
+            macroIsRecording(workbox);
+
             await editor.press('t');
             await editor.press('Escape');
             await editor.press('t');
             await editor.press('c');
             await expect(pos).toHaveText('Ln 1, Col 4');
             await editor.press('Shift+q');
+            macroIsNotRecording(workbox);
+
             await editor.press('Shift+3');
             await editor.press('h');
             await editor.press('q');
@@ -123,11 +158,15 @@ test.describe('Recorded keypresses', () => {
         test('Replays captures keys', async ({ workbox }) => {
             const { editor, pos } = await setup(workbox);
             await editor.press('Shift+q');
+            macroIsRecording(workbox);
+
             await editor.press('s');
             await editor.press('c');
             await editor.press(' ');
             await expect(pos).toHaveText('Ln 1, Col 4');
             await editor.press('Shift+q');
+            macroIsNotRecording(workbox);
+
             await editor.press('Shift+3');
             await editor.press('h');
             await editor.press('q');
@@ -140,6 +179,8 @@ test.describe('Recorded keypresses', () => {
         test('Replays captures keys with cancel', async ({ workbox }) => {
             const { editor, pos } = await setup(workbox);
             await editor.press('Shift+q');
+            macroIsRecording(workbox);
+
             await editor.press('s');
             await editor.press('Escape');
             await editor.press('s');
@@ -147,6 +188,8 @@ test.describe('Recorded keypresses', () => {
             await editor.press(' ');
             await expect(pos).toHaveText('Ln 1, Col 4');
             await editor.press('Shift+q');
+            macroIsNotRecording(workbox);
+
             await editor.press('Shift+3');
             await editor.press('h');
             await editor.press('q');
@@ -159,9 +202,13 @@ test.describe('Recorded keypresses', () => {
         test('Repeats replay using count', async ({ workbox }) => {
             const { editor, pos } = await setup(workbox);
             await editor.press('Shift+q');
+            macroIsRecording(workbox);
+
             await editor.press('l');
             await expect(pos).toHaveText('Ln 1, Col 2');
             await editor.press('Shift+q');
+            macroIsNotRecording(workbox);
+
             await editor.press('Shift+2');
             await editor.press('q');
             await editor.press('c');
@@ -175,6 +222,8 @@ test.describe('Recorded keypresses', () => {
         let editor = result.editor;
 
         await editor.press('Shift+q');
+        macroIsRecording(workbox);
+
         await editor.press('d');
         await editor.press('w');
         editor = workbox.getByLabel('macro.md').
@@ -183,6 +232,8 @@ test.describe('Recorded keypresses', () => {
         await editor.press('l');
         await expect(pos).toHaveText('Ln 1, Col 2');
         await editor.press('Shift+q');
+        macroIsNotRecording(workbox);
+
         await editor.press('q');
         await editor.press('q');
         await expect(pos).toHaveText('Ln 1, Col 3');
@@ -198,12 +249,16 @@ test.describe('Recorded keypresses', () => {
         let editor = result.editor;
 
         await editor.press('Shift+q');
+        macroIsRecording(workbox);
+
         await editor.press('i');
         await editor.press('x');
         editor = workbox.locator('[id="workbench.parts.editor"]').
             getByRole('textbox', { name: 'The editor is not accessible' });
         await editor.press('Escape');
         await editor.press('Shift+q');
+        macroIsNotRecording(workbox);
+
         await editor.press('q');
         await editor.press('q');
         await expect(pos).toHaveText('Ln 1, Col 3');
@@ -213,11 +268,15 @@ test.describe('Recorded keypresses', () => {
     test('Can nest replay', async ({ workbox }) => {
         const { editor, pos } = await setup(workbox);
         await editor.press('Shift+q');
+        macroIsRecording(workbox);
+
         await editor.press('l');
         await editor.press('q');
         await editor.press('l');
         await expect(pos).toHaveText('Ln 1, Col 3');
         await editor.press('Shift+q');
+        macroIsNotRecording(workbox);
+
         await editor.press('q');
         await editor.press('q');
         await expect(pos).toHaveText('Ln 1, Col 5');


### PR DESCRIPTION
The macro recording integration tests frequently fail because user input is presented before macro recording is done starting or done stopping. This adds checks to verify proper state of the UI providing user feedback about macro recording state.