### PR TITLE
bugfix: `kind` and `mode` items not always passed through from `source`

### DIFF
--- a/src/rust/parsing/src/file.rs
+++ b/src/rust/parsing/src/file.rs
@@ -3844,6 +3844,93 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn merge_source_kind_no_local_kinds() {
+        let source_data = r#"
+        #:master-keybindings
+
+        [header]
+        version = "2.1.0"
+        name = "Source"
+
+        [[kind]]
+        name = "motion"
+        description = "movement"
+        "#;
+
+        let data = r#"
+        #:master-keybindings
+
+        [header]
+        version = "2.2.0"
+        name = "User"
+        source = "Source"
+
+        [[bind]]
+        key = "j"
+        command = "cursorDown"
+        doc.kind = "motion"
+        "#;
+
+        let source = parse_keybinding_data(source_data, None);
+        let result = parse_keybinding_data(data, Some(&source));
+        assert!(
+            result.errors.as_ref().map_or(true, |v| v.is_empty()),
+            "Errors: {:?}",
+            result.errors
+        );
+        let result_file = result.file.unwrap();
+        assert_eq!(result_file.kind.len(), 1);
+        assert_eq!(result_file.kind[0].name, "motion");
+    }
+
+    #[test]
+    fn merge_source_mode_no_local_modes() {
+        let source_data = r#"
+        #:master-keybindings
+
+        [header]
+        version = "2.1.0"
+        name = "Source"
+
+        [[mode]]
+        name = "normal"
+        default = true
+        cursorShape = "Block"
+        whenNoBinding = "insertCharacters"
+
+        [[mode]]
+        name = "visual"
+        cursorShape = "Line"
+        "#;
+
+        let data = r#"
+        #:master-keybindings
+
+        [header]
+        version = "2.2.0"
+        name = "User"
+        source = "Source"
+
+        [[bind]]
+        key = "j"
+        command = "cursorDown"
+        mode = "visual"
+        "#;
+
+        let source = parse_keybinding_data(source_data, None);
+        let result = parse_keybinding_data(data, Some(&source));
+        assert!(
+            result.errors.as_ref().map_or(true, |v| v.is_empty()),
+            "Errors: {:?}",
+            result.errors
+        );
+        let result_file = result.file.unwrap();
+        assert!(result_file.mode.map.contains_key("visual"));
+    }
+
+
+
+    #[test]
     fn larkin_test() {
         // the default presets should be parseable (also a good "integration" test to ensure
         // our parsing works at scale)

--- a/src/rust/parsing/src/kind.rs
+++ b/src/rust/parsing/src/kind.rs
@@ -62,6 +62,7 @@ impl Kind {
         }
 
         let mut known_kinds = HashSet::new();
+        let mut result: Vec<_>;
         if let Some(input) = input {
             for kind in input.iter() {
                 let span = kind.span().clone();
@@ -90,23 +91,25 @@ impl Kind {
 
                 known_kinds.insert(kind_input.name.clone());
             }
-            scope.kinds = input.iter().map(|x| x.as_ref().name.clone()).collect();
-            let mut result: Vec<_> = input.iter().map(|x| x.as_ref().clone()).collect();
-            if let Some(source_file) = source {
-                scope
-                    .kinds
-                    .extend(source_file.kind.iter().map(|x| x.name.clone()));
-                result = source_file
-                    .kind
-                    .iter()
-                    .cloned()
-                    .chain(result.into_iter())
-                    .collect();
-            }
-
-            return Ok(result);
+            scope.kinds.extend(input.iter().map(|x| x.as_ref().name.clone()));
+            result = input.iter().map(|x| x.as_ref().clone()).collect();
         } else {
-            return Ok(Vec::new());
+            result = Vec::new();
         }
+
+        // prepend `source` [[kind]] if needed
+        if let Some(source_file) = source {
+            scope
+                .kinds
+                .extend(source_file.kind.iter().map(|x| x.name.clone()));
+            result = source_file
+                .kind
+                .iter()
+                .cloned()
+                .chain(result.into_iter())
+                .collect();
+        }
+
+        return Ok(result);
     }
 }


### PR DESCRIPTION
Closes #219 