### PR TITLE
Bugfix: silent errors when bindings are parsed differently or incorrectly synced

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "Master Key",
     "publisher": "haberdashPI",
     "description": "Master your keybindings with documentation, discoverability, modal bindings, macros and expressive configuration",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "icon": "logo.png",
     "repository": {
         "url": "https://github.com/haberdashPi/vscode-master-key"

--- a/src/extension/commands/do.ts
+++ b/src/extension/commands/do.ts
@@ -28,6 +28,7 @@ const masterBinding = z.object({
     old_prefix_id: z.number().int().min(-1),
     prefix: z.string(),
     mode: z.string(),
+    binding_hash: z.string(),
 });
 
 let documentIdentifierCount = 0;
@@ -166,7 +167,10 @@ export async function doCommandsCmd(args_: unknown): Promise<CommandResult> {
     try {
         const args = validateInput('master-key.do', args_, masterBinding);
         if (args) {
-            const toRun = bindings.prepare_binding_to_run(args.command_id);
+            const toRun = bindings.prepare_binding_to_run(
+                args.command_id,
+                args.binding_hash,
+            );
             showExpressionErrors(toRun);
 
             // if the current binding state, after obtaining a lock, doesn't match what's

--- a/src/extension/commands/prefix.ts
+++ b/src/extension/commands/prefix.ts
@@ -13,6 +13,7 @@ import {
     showPaletteOnDelay,
     triggerCommandCompleteHooks,
 } from './do';
+import { bindings } from '../keybindings/config';
 
 const prefixArgs = z.
     object({
@@ -23,6 +24,7 @@ const prefixArgs = z.
         prefix_id: z.number(),
         fromDo: z.boolean().default(true),
         key: z.string(),
+        binding_hash: z.string(),
         cursor: z.enum([
             'Line',
             'Block',
@@ -145,6 +147,28 @@ async function prefix(args_: unknown): Promise<CommandResult> {
 
     if (args !== undefined) {
         const release = !args.fromDo ? await commandMutex.acquire() : undefined;
+        // validate that our bindings in `keybindings.json` match the loaded binding
+        // state
+        const result = bindings.check_prefix_hash(args.binding_hash);
+        if (result === undefined) {
+            vscode.window.showErrorMessage(
+                'Internal error: bindings are not properly loaded, re-activate your ' +
+                'master keybindings.',
+            );
+            if (release) {
+                release();
+            }
+            return;
+        } else if (!result) {
+            vscode.window.showErrorMessage(
+                'Internal error: keybinding mismatch. Re-activate your master keybindings.',
+            );
+            if (release) {
+                release();
+            }
+            return;
+        }
+
         try {
             const a = args;
             const prefix = a.key;

--- a/src/rust/parsing/Cargo.lock
+++ b/src/rust/parsing/Cargo.lock
@@ -88,6 +88,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a65b545ab31d687cff52899d4890855fec459eb6afe0da6417b8a18da87aa29"
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -115,6 +124,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "const-random"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -135,10 +150,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer",
+ "const-oid",
+ "crypto-common",
+]
 
 [[package]]
 name = "env_filter"
@@ -199,6 +243,21 @@ name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "indexmap"
@@ -351,6 +410,7 @@ name = "parsing"
 version = "0.1.0"
 dependencies = [
  "env_logger",
+ "hex",
  "indexmap",
  "instant",
  "js-sys",
@@ -362,6 +422,7 @@ dependencies = [
  "serde",
  "serde-wasm-bindgen",
  "serde_spanned",
+ "sha2",
  "smallvec",
  "string-offsets",
  "test-log",
@@ -563,6 +624,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5417783452c2be558477e104686f7de5dae53dba813c28435e0e70f82d9b04ee"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -778,6 +850,12 @@ dependencies = [
  "tracing-core",
  "tracing-log",
 ]
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-ident"

--- a/src/rust/parsing/Cargo.toml
+++ b/src/rust/parsing/Cargo.toml
@@ -28,6 +28,8 @@ smallvec = { version = "1.15.1", features = ["serde"] }
 serde_spanned = "1.0.2"
 toml_datetime = "0.7.2"
 semver = { version = "1.0.27", features = ["serde"] }
+sha2 = "0.11.0"
+hex = "0.4.3"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/src/rust/parsing/src/bind.rs
+++ b/src/rust/parsing/src/bind.rs
@@ -1325,13 +1325,13 @@ pub struct BindingOutputArgs {
     pub(crate) priority: f64,
     // bindings defined implicitly via `mode` are flagged here
     pub(crate) implicit: bool,
-    // these fields are used in tracking and help improve legibility of the output bindings
-    // in the keybindings.json file, and so they are stored
     pub(crate) name: String,
     pub(crate) description: String,
     pub(crate) kind: String,
     pub(crate) prefix: String,
     pub(crate) mode: String,
+    // a hash used to identify the file used to define the current binding set
+    pub(crate) binding_hash: String,
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -1348,10 +1348,11 @@ pub struct PrefixArgs {
     pub(crate) command_id: i32,
     // human readable field displaying the key sequence pressed to reach prefix command
     pub(crate) key: String,
-    // these fields help us track and order binding outputs, we don't need them serialized
     #[serde(skip)]
     pub(crate) priority: f64,
     pub(crate) mode: String,
+    // a hash used to identify the file used to define the current binding set
+    pub(crate) binding_hash: String,
     // NOTE: there are other arguments to `master-key.prefix` but they are not used by
     // automatically generated bindings, which is what this type is for
 }
@@ -1598,6 +1599,7 @@ impl Binding {
     pub(crate) fn outputs(
         &self,
         command_id: i32,
+        binding_hash: &[u8; 32],
         scope: &Scope,
         is_source: bool,
         span: Option<Range<usize>>,
@@ -1605,6 +1607,7 @@ impl Binding {
         warnings: &mut Vec<ParseError>,
     ) -> ResultVec<Vec<BindingOutput>> {
         let mut result = Vec::new();
+        let binding_hash_str = hex::encode(binding_hash);
 
         // create a distinct binding for each mode...
         let mut modes = self.mode.clone();
@@ -1627,6 +1630,7 @@ impl Binding {
             for prefix in prefixes {
                 self.outputs_for_mode_and_prefix(
                     command_id,
+                    &binding_hash_str,
                     is_source,
                     &span,
                     &mode,
@@ -1679,6 +1683,7 @@ impl Binding {
     fn outputs_for_mode_and_prefix(
         &self,
         command_id: i32,
+        binding_hash_str: &str,
         is_source: bool,
         span: &Option<Range<usize>>,
         mode: &str,
@@ -1734,6 +1739,7 @@ impl Binding {
                     when: join_when_vec(&when),
                     args: PrefixArgs {
                         command_id,
+                        binding_hash: binding_hash_str.to_string(),
                         priority: 0.0,
                         key_id: key_code,
                         prefix_id: prefix_code,
@@ -1785,6 +1791,7 @@ impl Binding {
             when: join_when_vec(&when),
             args: BindingOutputArgs {
                 command_id,
+                binding_hash: String::from(binding_hash_str),
                 key_id: code,
                 prefix_id: prefix_code,
                 old_prefix_id: old_prefix_code,
@@ -1964,6 +1971,13 @@ impl ReifiedBinding {
             edit_text: String::new(),
             edit_document_id: -1,
         };
+    }
+
+    // error: a binding that results in some kind of error
+    pub fn with_error(scope: &mut Scope, msg: impl Into<String>) -> ReifiedBinding {
+        let mut result = Self::noop(scope);
+        result.error = Some(vec![msg.into()]);
+        return result;
     }
 
     // no-op: a command that does nothing, and may contain some information about possible

--- a/src/rust/parsing/src/file.rs
+++ b/src/rust/parsing/src/file.rs
@@ -182,6 +182,7 @@ use lazy_static::lazy_static;
 use regex::Regex;
 use semver::{Version, VersionReq};
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use std::collections::{HashMap, HashSet, VecDeque};
 use toml::Spanned;
 use wasm_bindgen::prelude::*;
@@ -255,6 +256,7 @@ pub struct KeyFile {
     pub(crate) mode: Modes,
     pub(crate) bind: Vec<Binding>,
     pub(crate) docs: Vec<FileDocSection>,
+    pub(crate) hash: [u8; 32],
     pub kind: Vec<Kind>,
     // TODO: avoid storing `key_bind` to make serialization smaller
     key_bind: Vec<BindingOutput>,
@@ -268,6 +270,7 @@ impl KeyFile {
         input: KeyFileInput,
         doc_lines: Vec<FileDocLine>,
         source: Option<&KeyFile>,
+        hasher: Sha256,
         mut scope: &mut Scope,
         warnings: &mut Vec<ParseError>,
     ) -> ResultVec<KeyFile> {
@@ -460,6 +463,12 @@ impl KeyFile {
         // TODO: store spans so we can do avoid serializing `key_bind`?
         let mut key_bind = Vec::new();
         bind = Binding::resolve_prefixes(bind, &bind_span)?;
+        // Compute the hash of this file's bindings before any `BindingOutput` is
+        // generated: every output records this hash so that `prepare_binding_to_run`
+        // can validate `command_id`s at runtime. Source bindings are not hashed here;
+        // the source file's own hash was already folded into `hasher` by
+        // `parse_bytes_helper`.
+        let hash = Self::compute_hash(hasher, bind.iter());
         let mut codes = BindingCodes::new();
         // add any bindings defined in the source file
         let mut source_offset = 0;
@@ -468,6 +477,7 @@ impl KeyFile {
             for (i, source_bind_item) in s.bind.iter().enumerate() {
                 key_bind.append(&mut source_bind_item.outputs(
                     i as i32,
+                    &hash,
                     &scope,
                     true,
                     Option::None,
@@ -480,6 +490,7 @@ impl KeyFile {
         for (i, (bind_item, span)) in bind.iter_mut().zip(bind_span.into_iter()).enumerate() {
             key_bind.append(&mut bind_item.outputs(
                 (i + source_offset) as i32,
+                &hash,
                 &scope,
                 false,
                 Some(span),
@@ -487,7 +498,6 @@ impl KeyFile {
                 warnings,
             )?);
         }
-
         // now that we've properly expanded this files bindings and any source
         // bindings we can combine them into a single vector
         let bind = if let Some(s) = source {
@@ -496,7 +506,7 @@ impl KeyFile {
             bind
         };
 
-        modes.insert_implicit_mode_bindings(&bind, &scope, &mut codes, &mut key_bind, warnings);
+        modes.insert_implicit_mode_bindings(&bind, &hash, &scope, &mut codes, &mut key_bind, warnings);
 
         // sort all bindings by their priority
         key_bind.sort_by(BindingOutput::cmp_priority);
@@ -528,11 +538,28 @@ impl KeyFile {
                 docs,
                 mode: modes,
                 kind,
+                hash,
                 key_bind: final_key_bind.into(),
             });
         } else {
             return Err(errors.into());
         }
+    }
+
+    fn compute_hash<'a>(
+        mut hasher: Sha256,
+        binds: impl Iterator<Item = &'a Binding>,
+    ) -> [u8; 32] {
+        for bind in binds {
+            Digest::update(&mut hasher, bind.key.join(" "));
+            if let Some(when_str) = &bind.when {
+                Digest::update(&mut hasher, when_str);
+            }
+            let mut mode_array = bind.mode.clone();
+            mode_array.sort();
+            Digest::update(&mut hasher, mode_array.join(" "));
+        }
+        hasher.finalize().0
     }
 }
 
@@ -675,21 +702,54 @@ impl KeyFileResult {
         };
     }
 
+    pub fn check_prefix_hash(&self, hash: &str) -> Option<bool> {
+        if let Some(KeyFile {
+            bind,
+            hash: binding_hash,
+            ..
+        }) = &self.file {
+            return Some(hex::encode(binding_hash) == hash)
+        }
+        return None
+    }
+
     // the first step of running bindings is to a get a list of `ReifiedBindings` (see
     // do.ts)
-    pub fn prepare_binding_to_run(&mut self, id: i32) -> ReifiedBinding {
-        if id == -1 {
+    pub fn prepare_binding_to_run(&mut self, command_id: i32, hash: &str) -> ReifiedBinding {
+        if command_id == -1 {
             return ReifiedBinding::noop(&mut self.scope);
         } else {
-            if let Some(KeyFile { bind, .. }) = &self.file {
-                if id < 0 || id as usize >= bind.len() {
-                    return ReifiedBinding::noop(&mut self.scope);
+            if let Some(KeyFile {
+                bind,
+                hash: binding_hash,
+                ..
+            }) = &self.file
+            {
+                if command_id < 0 || command_id as usize >= bind.len() {
+                    return ReifiedBinding::with_error(
+                        &mut self.scope,
+                        "Internal error: `command_id = {command_id}` is invalid. Try \
+                         re-activating your bindings.",
+                    );
                 } else {
-                    let binding = &bind[id as usize];
+                    let binding = &bind[command_id as usize];
+                    // check the hash, to verify that the command_id refers to the right
+                    // binding
+                    if hash != hex::encode(binding_hash) {
+                        return ReifiedBinding::with_error(
+                            &mut self.scope,
+                            "Binding file is out of date, re-activate your bindings",
+                        );
+                    }
+
                     return ReifiedBinding::new(&binding, &mut self.scope);
                 }
             } else {
-                return ReifiedBinding::noop(&mut self.scope);
+                return ReifiedBinding::with_error(
+                    &mut self.scope,
+                    "Internal error: no bindings have been loaded! \
+                     Try re-activating your bindings.",
+                );
             }
         }
     }
@@ -1019,18 +1079,28 @@ pub fn parse_bytes_helper(
     let parsed = toml::from_slice::<KeyFileInput>(file_content)?;
     let docs = FileDocLine::read(file_content);
 
+    // NOTE: we hash the data based on
+    // 1. the raw, un-parsed file contents (to ensure any file changes will change the hash)
+    // 2. the parsed data (to ensure any changes in how `[[bind]]` entries are read will
+    //    change the hash)
+    let mut hasher = Sha256::new();
+    Digest::update(&mut hasher, file_content);
+
     let source_file = match source {
         Some(source_data) => {
             // make sure any ASTs parsed in 'source' get carried over
             scope.transfer_asts(&source_data.scope)?;
+            if let Some(file) = &source_data.file {
+                Digest::update(&mut hasher, file.hash);
+            }
             source_data.file.as_ref()
         }
         Option::None => None,
     };
-    let result = KeyFile::new(parsed, docs, source_file, scope, warnings);
+    let result = KeyFile::new(parsed, docs, source_file, hasher, scope, warnings)?;
     warnings.append(&mut identify_legacy_warnings(file_content));
 
-    return result;
+    return Ok(result);
 }
 
 //

--- a/src/rust/parsing/src/mode.rs
+++ b/src/rust/parsing/src/mode.rs
@@ -624,6 +624,7 @@ impl Modes {
     pub(crate) fn insert_implicit_mode_bindings(
         &self,
         bindings: &Vec<Binding>,
+        hash: &[u8; 32],
         scope: &Scope,
         codes: &mut BindingCodes,
         key_bind: &mut Vec<BindingOutput>,
@@ -659,12 +660,13 @@ impl Modes {
             let mut implicit_bind = bind.clone();
             implicit_bind.mode = implicit_modes;
             implicit_bind.implicit = true;
-            let mut output =
-                match implicit_bind.outputs(id as i32, &scope, false, None, codes, warnings) {
-                    Ok(x) => x,
-                    // silently ignore errors; these will be reported for the explicit bindings
-                    Err(_) => Vec::new(),
-                };
+            let mut output = match implicit_bind
+                .outputs(id as i32, hash, &scope, false, None, codes, warnings)
+            {
+                Ok(x) => x,
+                // silently ignore errors; these will be reported for the explicit bindings
+                Err(_) => Vec::new(),
+            };
             key_bind.append(&mut output);
         }
     }


### PR DESCRIPTION
We now use a hash of the binding file and its parsed result to validate `command_id`s, to avoid silent errors where the wrong command is run. This typically occurs because of a mismatch between the version of master key currently enabled, and the version originally used to activate the bindings.

Closes: #136, #224 

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>