### PR TITLE
Docs: 'source' bindings are now prepended to keybinding documentation

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -127,7 +127,7 @@ components = "llvm-tools-preview"
 targets = "wasm32-unknown-unknown"
 
 [[tools.rust]]
-version = "nightly"
+version = "nightly-2026-08-20"
 backend = "core:rust"
 
 [tools.rust.options]

--- a/mise.toml
+++ b/mise.toml
@@ -25,7 +25,7 @@ targets = "wasm32-unknown-unknown"
 components = "llvm-tools-preview"
 
 [[tools.rust]]
-version = "nightly"
+version = "nightly-2026-08-20"
 targets = "wasm32-unknown-unknown"
 components = "llvm-tools-preview"
 
@@ -43,10 +43,7 @@ run = 'pnpm exec eslint src'
 
 [tasks.check-types]
 depends = ['build-rust']
-run = [
-    'tsc --noEmit --project tsconfig.json',
-    'tsc --noEmit --project src/webview',
-]
+run = ['tsc --noEmit --project tsconfig.json', 'tsc --noEmit --project src/webview']
 
 # TODO: maybe consider using colons and figure out mise task hierarchies???
 [tasks.build-rust]
@@ -60,6 +57,7 @@ run = [
 ]
 
 [vars]
+nightly_version = "nightly-2026-08-20"
 coverage_options = '''--ignore-filename-regex '/.cargo/registry' --ignore-filename-regex '.rustup/toolchains' --ignore-filename-regex 'rustc/' --compilation-dir src/rust/parsing --instr-profile coverage/parsing.profdata --Xdemangler rustfilt'''
 
 [tasks.test-rust]
@@ -72,19 +70,20 @@ def main [...args] {
         $env.RUSTFLAGS = '-C instrument-coverage --cfg coverage_nightly'
         $env.LLVM_PROFILE_FILE = 'coverage/parsing.profraw'
 
-        cargo +nightly test --tests --no-run
+        cargo +{{vars.nightly_version}} test --tests --no-run
 
-        let object_files = cargo +nightly test --lib --no-run --message-format=json |
+        let object_files = cargo +{{vars.nightly_version}} test --lib --no-run --message-format=json |
             from json -o | where profile?.test |
             get filenames.0 |
             each { |f| $'--object=($in)' }
 
-        cargo +nightly test --lib ...$args -- --nocapture
-        cargo +nightly profdata -- merge -sparse coverage/parsing.profraw -o coverage/parsing.profdata
-        (cargo +nightly cov -- export {{vars.coverage_options}} --format=lcov ...($object_files) o>
+        cargo +{{vars.nightly_version}} test --lib ...$args -- --nocapture
+        cargo +{{vars.nightly_version}} profdata -- merge -sparse coverage/parsing.profraw -o coverage/parsing.profdata
+        (cargo +{{vars.nightly_version}} cov -- export {{vars.coverage_options}} --format=lcov ...($object_files) o>
             coverage/parsing.info)
 
-        cargo +nightly cov -- report --use-color {{vars.coverage_options}} ...($object_files)
+        cargo +{{vars.nightly_version}} cov -- report --use-color {{vars.coverage_options}} ...($object_files)
+        mkdir ../../../coverage
         cp coverage/parsing.info ../../../coverage/rs_coverage.info
     } else {
         cargo test ...$args -- --nocapture

--- a/src/rust/parsing/src/file.rs
+++ b/src/rust/parsing/src/file.rs
@@ -456,7 +456,7 @@ impl KeyFile {
             })
             .unzip();
 
-        let docs = FileDocSection::assemble(&bind, &bind_span, doc_lines);
+        let mut docs = FileDocSection::assemble(&bind, &bind_span, doc_lines);
         FileDocSection::assign_binding_headings(&mut bind, &docs);
 
         // create outputs to store in `keybindings.json`
@@ -485,6 +485,8 @@ impl KeyFile {
                     warnings,
                 )?);
             }
+
+            docs = s.docs.iter().cloned().chain(docs.iter().cloned()).collect();
         }
         // add the bindings defined directly in this file
         for (i, (bind_item, span)) in bind.iter_mut().zip(bind_span.into_iter()).enumerate() {


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>