### PR TITLE
Larkin: replace `editorHasMultilineSelection` with `selection-utilities.editorHasMultilineSelection`

### DIFF
--- a/src/presets/larkin.toml
+++ b/src/presets/larkin.toml
@@ -351,14 +351,14 @@ doc.description = """
 Without a count: change selected region or all text on the current line if there is
 no selection. With a count: change up to `count` lines.
 """
-when = "editorHasMultilineSelection"
+when = "selection-utilities.editorHasMultilineSelection"
 command = "runCommands"
 args.commands = ["deleteRight", "editor.action.insertLineBefore", "master-key.enterInsert"]
 
 [[bind]]
 default = "{{bind.edit_action}}"
 key = "c"
-when = "!editorHasMultilineSelection && editorHasSelection"
+when = "!selection-utilities.editorHasMultilineSelection && editorHasSelection"
 command = "runCommands"
 args.commands = ["deleteRight", "master-key.enterInsert"]
 


### PR DESCRIPTION
The previous command did not actually exist, and a version of it will be implemented in https://github.com/haberdashPI/vscode-selection-utilities/pull/94

This should not merge until https://github.com/haberdashPI/vscode-selection-utilities/pull/94 merges and a new release of `selection-utilities` is created.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>