### PR TITLE
Bugfix: `requiredExtensions` not merged when using `source`

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "Master Key",
     "publisher": "haberdashPI",
     "description": "Master your keybindings with documentation, discoverability, modal bindings, macros and expressive configuration",
-    "version": "1.3.1",
+    "version": "1.3.2",
     "icon": "logo.png",
     "repository": {
         "url": "https://github.com/haberdashPi/vscode-master-key"

--- a/src/rust/parsing/src/file.rs
+++ b/src/rust/parsing/src/file.rs
@@ -318,6 +318,17 @@ impl KeyFile {
             .flatten()
             .collect();
 
+        #[allow(non_snake_case)]
+        let requiredExtensions = if let Some(s) = source {
+            s.requiredExtensions
+                .iter()
+                .cloned()
+                .chain(requiredExtensions.into_iter())
+                .collect()
+        } else {
+            requiredExtensions
+        };
+
         // [[define]]
         let mut define_input = input.define.unwrap_or_default();
         let mut skip_define = false;
@@ -486,7 +497,7 @@ impl KeyFile {
                 )?);
             }
 
-            docs = s.docs.iter().cloned().chain(docs.iter().cloned()).collect();
+            docs = s.docs.iter().cloned().chain(docs.into_iter()).collect();
         }
         // add the bindings defined directly in this file
         for (i, (bind_item, span)) in bind.iter_mut().zip(bind_span.into_iter()).enumerate() {


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>