### PR TITLE
Larkin: fix bug in master key `search`s `skip=-1` parameter

### DIFF
--- a/src/extension/commands/search.ts
+++ b/src/extension/commands/search.ts
@@ -86,7 +86,7 @@ export const searchArgs = z.
             by: z.number(),
         })),
         register: z.string().default('default'),
-        skip: z.number().min(-1).optional().default(0),
+        skip: z.number().min(-1).default(0),
     }).
     strict().
     transform((data) => {

--- a/src/presets/larkin.toml
+++ b/src/presets/larkin.toml
@@ -1207,7 +1207,7 @@ doc.combined.name = "find char (back)"
 doc.combined.description = "Find the next (previous) char (include char in selection)"
 doc.combined.key = "f (shift+f)"
 args.acceptAfter = 1
-args.skip = "{{key.count-1}}"
+args.skip = "{{max(0, key.count-1)}}"
 args.offset = "fartherBoundary"
 
 [[bind]]
@@ -1219,7 +1219,7 @@ doc.combined.name = "find char (back)"
 args.acceptAfter = 1
 args.offset = "fartherBoundary"
 args.backwards = true
-args.skip = "{{key.count-1}}"
+args.skip = "{{max(0, key.count-1)}}"
 
 [[bind]]
 default = "{{bind.edit_motion_search}}"
@@ -1231,7 +1231,7 @@ doc.combined.key = "t (shift+t)"
 doc.combined.description = "Find the next/previous char (exclude char in selection)"
 args.acceptAfter = 1
 args.offset = "start"
-args.skip = "{{key.count-1}}"
+args.skip = "{{max(0, key.count-1)}}"
 
 [[bind]]
 default = "{{bind.edit_motion_search}}"
@@ -1242,7 +1242,7 @@ doc.combined.name = "to char (back)"
 args.acceptAfter = 1
 args.offset = "end"
 args.backwards = true
-args.skip = "{{key.count-1}}"
+args.skip = "{{max(0, key.count-1)}}"
 
 [[bind]]
 default = "{{bind.edit_motion_search}}"
@@ -1254,7 +1254,7 @@ doc.combined.description = "To next character pair"
 doc.combined.key = "s/shift+s"
 args.acceptAfter = 2
 args.offset = "start"
-args.skip = "{{key.count-1}}"
+args.skip = "{{max(0, key.count-1)}}"
 mode = "normal"
 
 [[bind]]
@@ -1265,7 +1265,7 @@ doc.description = "To previous character pair"
 doc.combined.name = "char pair →/←"
 args.acceptAfter = 2
 args.offset = "start"
-args.skip = "{{key.count-1}}"
+args.skip = "{{max(0, key.count-1)}}"
 args.backwards = true
 
 ## ## Advanced Commands
@@ -1397,7 +1397,7 @@ command = "cursorMove"
 args.to = "down"
 args.by = "wrappedLine"
 args.select = true
-args.value = "{{key.count-1}}"
+args.value = "{{max(0, key.count-1)}}"
 
 [[bind.args.commands]]
 command = "revealLine"


### PR DESCRIPTION
Introduced by implementing support by `skip=-1`.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>