### PR TITLE
build harness: `--install-extension` defined as a separate task

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,16 +12,12 @@
             "args": [
                 "--extensionDevelopmentPath=${workspaceFolder}",
                 "--profile",
-                "master-key-debug",
-                "--install-extension",
-                "tamasfe.even-better-toml",
-                "--install-extension",
-                "haberdashPI.selection-utilities"
+                "master-key-debug"
             ],
             "outFiles": [
                 "${workspaceFolder}/out/node/**/*.js"
             ],
             "preLaunchTask": "${defaultBuildTask}"
-        },
+        }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,6 +4,15 @@
     "version": "2.0.0",
     "tasks": [
         {
+            "label": "install-debug-extensions",
+            "type": "shell",
+            "command": "code --profile master-key-debug --install-extension tamasfe.even-better-toml --install-extension haberdashPI.selection-utilities",
+            "presentation": {
+                "reveal": "silent"
+            }
+        },
+        {
+            "label": "mise: watch build",
             "type": "shell",
             "command": "mise watch build",
             "problemMatcher": [
@@ -40,6 +49,7 @@
                         {
                             "regexp": "^\\[lint\\]\\s(.*ts)\\s*$",
                             "file": 1,
+                            "line": 2
                         }
                     ]
                 },
@@ -57,18 +67,26 @@
                             "regexp": "^\\[Command "
                         }
                     }
-                },
+                }
             ],
             "isBackground": true,
-            "label": "npm: watch:esbuild",
             "presentation": {
                 "group": "watch",
                 "reveal": "never"
-            },
+            }
+        },
+        {
+            "label": "prepare-and-watch",
+            "dependsOn": [
+                "install-debug-extensions",
+                "mise: watch build"
+            ],
+            "dependsOrder": "sequence",
             "group": {
                 "kind": "build",
                 "isDefault": true
-            }
-        },
+            },
+            "problemMatcher": []
+        }
     ]
 }


### PR DESCRIPTION
In older versions of vscode it was possible to install extensions and then start a debug session in a single call to `code`. In more recent versions
this causes a premature termination after the extensions have been installed. This separates the installation of supporting extensions and the debug run into separate calls to `code`.
