### PR TITLE
Documentation: change default keybinding to cycle through keybinding modifiers

### DIFF
--- a/package.json
+++ b/package.json
@@ -223,8 +223,8 @@
                 "command": "master-key.toggleSuggestions"
             },
             {
-                "key": "ctrl+k ctrl+shift+m",
-                "mac": "cmd+k cmd+shift+m",
+                "key": "ctrl+k tab",
+                "mac": "cmd+k tab",
                 "command": "master-key.toggleVisualDocModifiers"
             }
         ],

--- a/src/extension/commands/visualKeyDoc.ts
+++ b/src/extension/commands/visualKeyDoc.ts
@@ -451,8 +451,7 @@ export class DocViewProvider implements vscode.WebviewViewProvider {
         const keys = `
         <div id="master-key-visual-doc" class="container">
             <p>To see additional bindings use the command \`Mater Key: Toggle Visual
-                Doc Modifier by frequency\` (default keybinding
-                ctrl/cmd+k ctrl/cmd+shift+m)</p>
+                Doc Modifier by frequency\` (default keybinding ctrl/cmd+k tab)</p>
 
             <div class="keyboard">
                 ${keyRows(['⇧'], ['']).


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>