### PR TITLE
bugfix: prefixes in status bar are incorrectly reported

### DIFF
--- a/src/extension/commands/do.ts
+++ b/src/extension/commands/do.ts
@@ -129,12 +129,24 @@ function commandChangesModeOrPrefix(command: ReifiedBinding) {
 // used to ensure orderly execution of commands within `master-key.do`
 export const commandMutex = new Mutex();
 
-function prependPrefix(prefix: string, suffix: string) {
+function prependPrefix(prefix: string, key: string) {
+    // `key` can be either the complete sequence of keys or a suffix thereof, depending on
+    // whether `[[bind]]` includes an explicit prefix or an implicit prefix (explicit
+    // prefixes are defined using the `prefix` field of `[[bind]]`). To ensure we have the
+    // complete key sequence, we determine the *entire* prefix from what is stored under
+    // `args.prefix` (this will always be the full prefix; this is produced near the end of
+    // `outputs_for_mode_and_prefix` in `bind.rs`).
+    const suffix = finalKeyInSequence(key);
     if (prefix.length > 0) {
         return prefix + ' ' + suffix;
     } else {
         return suffix;
     }
+}
+
+function finalKeyInSequence(key: string) {
+    const chords = key.split(' ');
+    return chords[chords.length - 1];
 }
 
 /**

--- a/src/test/integration/press-keybindings.test.ts
+++ b/src/test/integration/press-keybindings.test.ts
@@ -123,6 +123,37 @@ test.describe('Basic keypresses', () => {
         });
     }
 
+    if (process.env.CI !== 'true') {
+        test('Displays key prefixes correctly for implicit and explicit prefixes',
+            async ({ workbox }) => {
+                const { editor, pos } = await setup(workbox, 'simpleMotions.toml');
+                const keys = workbox.locator('[id="haberdashPI.master-key.keys"]');
+
+                // implicit prefix: `g g` is a single binding whose own `key` field is
+                // itself multi-chord -- regression test for the leading chord getting
+                // doubled (e.g. showing "G, G, G" instead of "G, G") when the triggering
+                // chord is combined with the already-accumulated prefix.
+                await editor.press('g');
+                await expect(keys.getByLabel(/^Keys Typed: G$/)).toBeVisible();
+                await editor.press('g');
+                await expect(keys.getByLabel(/^Keys Typed: G, G$/)).toBeVisible();
+                await expect(pos).toHaveText('Ln 3, Col 1');
+                // let the delayed status bar clear finish before starting the next sequence
+                await workbox.waitForTimeout(600);
+
+                // explicit prefix: `d` sets the prefix via an explicit call to
+                // `master-key.prefix`, and a *separate* `w` binding (gated on
+                // `prefixes.anyOf = ["d", ...]`) continues it -- regression test for #166
+                // (the two bindings must still combine into a single displayed sequence,
+                // without also double-counting the `d`).
+                await editor.press('d');
+                await expect(keys.getByLabel(/^Keys Typed: D$/)).toBeVisible();
+                await editor.press('w');
+                await expect(keys.getByLabel(/^Keys Typed: D, W$/)).toBeVisible();
+            },
+        );
+    }
+
     test('Updates `capture` variable', async ({ workbox }) => {
         const { editor, pos } = await setup(workbox, 'simpleMotions.toml');
         await editor.press('t');


### PR DESCRIPTION
An old bugifx (#202) only papered over the problem with prefix display. It solved incorrect display of explicit prefixes. (An explicit prefix is one specified via the `prefix` keyword of `[[bind]]`). 

The bugfix here ensures that both explicit and implicit prefixes are properly displayed in the status bar.

Closes #249
